### PR TITLE
Ens content hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Depricated: [ Resolution#ipfsHash, Resolution#ipfsRedirect, Resolution#email ] -> use Resolution#ipfs || Resolution#whois
 * Domain that starts and ends with '-' are not valid anymore.
 
 ## 1.0.9-1.0.10

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@ensdomains/address-encoder": "^0.1.2",
     "bip44-constants": "^8.0.4",
+    "content-hash": "^2.5.2",
     "eth-ens-namehash": "^2.0.8",
     "ethers": "^4.0.39",
     "keccak256": "^1.0.0",

--- a/src/Cns.test.ts
+++ b/src/Cns.test.ts
@@ -166,11 +166,13 @@ describe('CNS', () => {
     expect(addr).toBe('zil1yu5u4hegy9v3xgluweg4en54zm8f8auwxu0xxj');
   });
 
-  describe("namehash", () => {
-    it("supports root node", async () => {
+  describe('namehash', () => {
+    it('supports root node', async () => {
       const resolution = new Resolution();
       expect(resolution.isSupportedDomain('crypto')).toEqual(true);
-      expect(new Resolution().namehash('crypto')).toEqual('0x0f4a10a4f46c288cea365fcf45cccf0e9d901b945b9829ccdb54c10dc3cb7a6f');
+      expect(new Resolution().namehash('crypto')).toEqual(
+        '0x0f4a10a4f46c288cea365fcf45cccf0e9d901b945b9829ccdb54c10dc3cb7a6f',
+      );
     });
   });
 
@@ -179,8 +181,7 @@ describe('CNS', () => {
       const resolution = new Resolution();
       const ipfs = await resolution.ipfs(labelDomain);
       const whois = await resolution.whois(labelDomain);
-      console.log({ipfs, whois});
-
-    })
-  })
+      console.log({ ipfs, whois });
+    });
+  });
 });

--- a/src/Cns.test.ts
+++ b/src/Cns.test.ts
@@ -173,4 +173,14 @@ describe('CNS', () => {
       expect(new Resolution().namehash('crypto')).toEqual('0x0f4a10a4f46c288cea365fcf45cccf0e9d901b945b9829ccdb54c10dc3cb7a6f');
     });
   });
+
+  describe('meta data', () => {
+    it('should resolve with correct metaData', async () => {
+      const resolution = new Resolution();
+      const ipfs = await resolution.ipfs(labelDomain);
+      const whois = await resolution.whois(labelDomain);
+      console.log({ipfs, whois});
+
+    })
+  })
 });

--- a/src/Ens.test.ts
+++ b/src/Ens.test.ts
@@ -413,4 +413,23 @@ describe('ENS', () => {
     });
   });
 
+  describe('ContentHash', () => {
+    it('should get an ipfsHash ', async () => {
+      const resolution = new Resolution();
+      const hash = await resolution.ipfsHash('almonit.eth');
+      expect(hash).toBe('QmV3RLU7X2QBaBJ7vdkYJPtiYVTdfWaQD6RetzFUzmrJf3');
+    });
+  });
+
+  describe('whois', () => {
+    it('should resolve a whois ', async () => {
+      const resolution = new Resolution();
+      const whois = await resolution.whois('almonit.eth');
+      expect(whois).toStrictEqual(
+        { email: '', url: '', avatar: '', description: '', notice: '' }
+      );
+    });
+
+    //todo: Find some domains with valid info on whois
+  });
 });

--- a/src/Ens.test.ts
+++ b/src/Ens.test.ts
@@ -108,7 +108,11 @@ describe('ENS', () => {
       blockchain: { ens: MainnetUrl },
     });
 
-    const ownerEye = mockAsyncMethod(resolution.ens, 'getOwner', NullAddress[1]);
+    const ownerEye = mockAsyncMethod(
+      resolution.ens,
+      'getOwner',
+      NullAddress[1],
+    );
     const result = await resolution.address('something.luxe', 'ETH');
     expectSpyToBeCalled([ownerEye]);
     expect(result).toEqual(null);
@@ -397,19 +401,17 @@ describe('ENS', () => {
       getOwner: '0x714ef33943d925731FBB89C99aF5780D888bD106',
       getResolver: '0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8',
       getTTL: 0,
-      callMethod:
-        '0x714ef33943d925731FBB89C99aF5780D888bD106',
+      callMethod: '0x714ef33943d925731FBB89C99aF5780D888bD106',
     });
     const resolutionObj = await resolution.resolve('matthewgould.eth');
     expectSpyToBeCalled(eyes);
     expect(resolutionObj).toStrictEqual({
       addresses: { ETH: '0x714ef33943d925731FBB89C99aF5780D888bD106' },
-      meta:
-      {
+      meta: {
         owner: '0x714ef33943d925731FBB89C99aF5780D888bD106',
         type: 'ENS',
-        ttl: 0
-      }
+        ttl: 0,
+      },
     });
   });
 
@@ -425,9 +427,13 @@ describe('ENS', () => {
     it('should resolve a whois ', async () => {
       const resolution = new Resolution();
       const whois = await resolution.whois('almonit.eth');
-      expect(whois).toStrictEqual(
-        { email: '', url: '', avatar: '', description: '', notice: '' }
-      );
+      expect(whois).toStrictEqual({
+        email: '',
+        url: '',
+        avatar: '',
+        description: '',
+        notice: '',
+      });
     });
 
     //todo: Find some domains with valid info on whois

--- a/src/Resolution.test.ts
+++ b/src/Resolution.test.ts
@@ -83,18 +83,17 @@ describe('Resolution', () => {
     const resolution = new Resolution();
     await expectResolutionErrorCode(
       () => resolution.namehash('-hello.eth'),
-      ResolutionErrorCode.UnsupportedDomain
+      ResolutionErrorCode.UnsupportedDomain,
     );
-  })
+  });
 
   it('should be invalid domain 2', async () => {
     const resolution = new Resolution();
     await expectResolutionErrorCode(
       () => resolution.namehash('whatever-.eth'),
-      ResolutionErrorCode.UnsupportedDomain
+      ResolutionErrorCode.UnsupportedDomain,
     );
-  })
-
+  });
 
   describe('serviceName', () => {
     it('checks ens service name', () => {
@@ -128,33 +127,33 @@ describe('Resolution', () => {
     });
 
     it('checks naming service via api', () => {
-      const resolution = new Resolution({blockchain: false});
+      const resolution = new Resolution({ blockchain: false });
       const serviceName = resolution.serviceName('domain.zil');
       expect(serviceName).toBe('ZNS');
     });
 
     it('checks naming service via api 2', () => {
-      const resolution = new Resolution({blockchain: false});
+      const resolution = new Resolution({ blockchain: false });
       const serviceName = resolution.serviceName('domain.luxe');
       expect(serviceName).toBe('ENS');
     });
 
     it('checks naming service via api 3', () => {
-      const resolution = new Resolution({blockchain: false});
+      const resolution = new Resolution({ blockchain: false });
       const serviceName = resolution.serviceName('domain.xyz');
       expect(serviceName).toBe('ENS');
     });
 
     it('checks naming service via api 4', () => {
-      const resolution = new Resolution({blockchain: false});
+      const resolution = new Resolution({ blockchain: false });
       const serviceName = resolution.serviceName('domain.eth');
       expect(serviceName).toBe('ENS');
     });
 
     it('checks naming service via api 5', () => {
-      const resolution = new Resolution({blockchain: false});
+      const resolution = new Resolution({ blockchain: false });
       const serviceName = resolution.serviceName('domain.crypto');
       expect(serviceName).toBe('CNS');
     });
-  })
+  });
 });

--- a/src/Resolution.ts
+++ b/src/Resolution.ts
@@ -7,11 +7,12 @@ import {
   UnclaimedDomainResponse,
   ResolutionResponse,
   DefaultAPI,
-  API
+  API,
+  IPFS,
+  WHOIS,
 } from './types';
 import ResolutionError, { ResolutionErrorCode } from './resolutionError';
 import NamingService from './namingService';
-
 /**
  * Blockchain domain Resolution library - Resolution.
  * @example
@@ -100,12 +101,32 @@ export default class Resolution {
   }
 
   /**
+   * Resolves the ipfs metadata from the domain
+   * @param domain - domain name
+   */
+  async ipfs(domain: string): Promise<IPFS> {
+    return await this.getNamingMethodOrThrow(domain).ipfs(domain);
+  }
+
+  /**
+   * Resolves whois metadata from the domain
+   * @param domain - domain name
+   */
+  async whois(domain: string): Promise<WHOIS> {
+    return await this.getNamingMethodOrThrow(domain).whois(domain);
+  }
+
+  /**
    * Resolves the ipfs hash configured for domain records on ZNS
+   * @deprecated
    * @param domain - domain name
    * @throws ResolutionError
    * @returns A Promise that resolves in ipfsHash
    */
   async ipfsHash(domain: string): Promise<string> {
+    const method = this.getNamingMethodOrThrow(domain) as any;
+    if (method.name === 'ENS')
+      return await method.ipfsHash(this.namehash(domain));
     return await this.getNamingMethodOrThrow(domain).record(
       domain,
       'ipfs.html.value',
@@ -114,6 +135,7 @@ export default class Resolution {
 
   /**
    * Resolves the ipfs redirect url for a supported domain records
+   * @deprecated
    * @param domain - domain name
    * @throws ResolutionError
    * @returns A Promise that resolves in redirect url
@@ -127,6 +149,7 @@ export default class Resolution {
 
   /**
    * Resolves the ipfs email field from whois configurations
+   * @deprecated
    * @param domain - domain name
    * @throws ResolutionError
    * @returns A Promise that resolves in an email address configured for this domain whois

--- a/src/Resolution.ts
+++ b/src/Resolution.ts
@@ -37,7 +37,10 @@ export default class Resolution {
    * Resolution constructor
    * @property blockchain - main configuration object
    */
-  constructor({ blockchain = true, api = DefaultAPI }: { blockchain?: Blockchain, api?: API } = {}) {
+  constructor({
+    blockchain = true,
+    api = DefaultAPI,
+  }: { blockchain?: Blockchain; api?: API } = {}) {
     this.blockchain = !!blockchain;
     if (blockchain) {
       if (blockchain == true) {

--- a/src/Zns.test.ts
+++ b/src/Zns.test.ts
@@ -292,16 +292,20 @@ describe('ZNS', () => {
     it('should return whois method', async () => {
       const resolution = new Resolution();
       const whois = await resolution.whois('ergergergerg.zil');
-      expect(whois).toStrictEqual({ email: 'matt+test@unstoppabledomains.com',
-      url: 'www.unstoppabledomains.com',
-      for_sale: true });
+      expect(whois).toStrictEqual({
+        email: 'matt+test@unstoppabledomains.com',
+        url: 'www.unstoppabledomains.com',
+        for_sale: true,
+      });
     });
 
     it('should return ipfs method', async () => {
       const resolution = new Resolution();
       const ipfs = await resolution.ipfs('ergergergerg.zil');
-      expect(ipfs).toStrictEqual({ hash: 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHu',
-      redirect: 'www.unstoppabledomains.com' } );
+      expect(ipfs).toStrictEqual({
+        hash: 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHu',
+        redirect: 'www.unstoppabledomains.com',
+      });
     });
   });
 });

--- a/src/Zns.test.ts
+++ b/src/Zns.test.ts
@@ -5,6 +5,7 @@ import {
   ZilliqaUrl,
   mockAPICalls,
 } from './utils/testHelpers';
+import ResolutionError from './resolutionError';
 
 beforeEach(() => {
   jest.restoreAllMocks();
@@ -286,4 +287,21 @@ describe('ZNS', () => {
   //     },
   //   });
   // });
+
+  describe('Meta data', () => {
+    it('should return whois method', async () => {
+      const resolution = new Resolution();
+      const whois = await resolution.whois('ergergergerg.zil');
+      expect(whois).toStrictEqual({ email: 'matt+test@unstoppabledomains.com',
+      url: 'www.unstoppabledomains.com',
+      for_sale: true });
+    });
+
+    it('should return ipfs method', async () => {
+      const resolution = new Resolution();
+      const ipfs = await resolution.ipfs('ergergergerg.zil');
+      expect(ipfs).toStrictEqual({ hash: 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHu',
+      redirect: 'www.unstoppabledomains.com' } );
+    });
+  });
 });

--- a/src/cns.ts
+++ b/src/cns.ts
@@ -4,6 +4,8 @@ import {
   RegistryMap,
   ResolutionResponse,
   isNullAddress,
+  IPFS,
+  WHOIS,
 } from './types';
 import { default as resolverInterface } from './cns/contract/resolver';
 import { default as cnsInterface } from './cns/contract/registry';
@@ -101,6 +103,19 @@ export default class Cns extends EthereumNamingService {
     return addr;
   }
 
+  async ipfs(domain: string): Promise<IPFS> {
+    const hashPromise = await this.record(domain, 'ipfs.html');
+    // const redirect = await this.record(domain, 'ipfs.redirect_domain');
+    const redirect = "";
+    return {hash: hashPromise, redirect};
+  }
+
+  async whois(domain: string): Promise<WHOIS> {
+    const emailPromise = this.record(domain, 'whois.email');
+    const urlPromise = this.record(domain, 'ipfs.redirect_domain');
+    return await Promise.all([emailPromise, urlPromise]).then(([email, url]) => {return {email, url}});
+  }
+
   /**
    * @internal
    * @param resolver - Resolver address
@@ -146,7 +161,7 @@ export default class Cns extends EthereumNamingService {
   /** @internal */
   async record(domain: string, key: string): Promise<string> {
     const tokenId = this.namehash(domain);
-    const resolver: string = await this.getResolver(tokenId);
+    const resolver: string = await this.getResolver(tokenId);    
     const resolverContract = this.buildContract(
       resolverInterface,
       resolver,

--- a/src/cns.ts
+++ b/src/cns.ts
@@ -66,7 +66,10 @@ export default class Cns extends EthereumNamingService {
    * @returns
    */
   isSupportedDomain(domain: string): boolean {
-    return domain === "crypto" || (domain.indexOf('.') > 0 && /^.{1,}\.(crypto)$/.test(domain));
+    return (
+      domain === 'crypto' ||
+      (domain.indexOf('.') > 0 && /^.{1,}\.(crypto)$/.test(domain))
+    );
   }
 
   /**
@@ -106,14 +109,18 @@ export default class Cns extends EthereumNamingService {
   async ipfs(domain: string): Promise<IPFS> {
     const hashPromise = await this.record(domain, 'ipfs.html');
     // const redirect = await this.record(domain, 'ipfs.redirect_domain');
-    const redirect = "";
-    return {hash: hashPromise, redirect};
+    const redirect = '';
+    return { hash: hashPromise, redirect };
   }
 
   async whois(domain: string): Promise<WHOIS> {
     const emailPromise = this.record(domain, 'whois.email');
     const urlPromise = this.record(domain, 'ipfs.redirect_domain');
-    return await Promise.all([emailPromise, urlPromise]).then(([email, url]) => {return {email, url}});
+    return await Promise.all([emailPromise, urlPromise]).then(
+      ([email, url]) => {
+        return { email, url };
+      },
+    );
   }
 
   /**
@@ -126,10 +133,7 @@ export default class Cns extends EthereumNamingService {
     tokenId: string,
     coinName?: string,
   ): Promise<string> {
-    const resolverContract = this.buildContract(
-      resolverInterface,
-      resolver,
-    );
+    const resolverContract = this.buildContract(resolverInterface, resolver);
     const addrKey = `crypto.${coinName.toUpperCase()}.address`;
     const addr: string = await this.getRecord(resolverContract, 'get', [
       addrKey,
@@ -140,11 +144,16 @@ export default class Cns extends EthereumNamingService {
 
   /** @internal */
   private getResolver = async (tokenId): Promise<string> =>
-    await this.callMethod(this.registryContract, 'resolverOf', [tokenId]).catch((err) => {
-      if (err instanceof ResolutionError && err.code === ResolutionErrorCode.RecordNotFound)
-        return undefined;
-      throw err;
-    });
+    await this.callMethod(this.registryContract, 'resolverOf', [tokenId]).catch(
+      err => {
+        if (
+          err instanceof ResolutionError &&
+          err.code === ResolutionErrorCode.RecordNotFound
+        )
+          return undefined;
+        throw err;
+      },
+    );
 
   /** @internal */
   async owner(tokenId): Promise<string> {
@@ -155,17 +164,13 @@ export default class Cns extends EthereumNamingService {
     contract: Contract,
     methodname: string,
     params: any[],
-  ): Promise<string> =>
-    await this.callMethod(contract, methodname, params);
+  ): Promise<string> => await this.callMethod(contract, methodname, params);
 
   /** @internal */
   async record(domain: string, key: string): Promise<string> {
     const tokenId = this.namehash(domain);
-    const resolver: string = await this.getResolver(tokenId);    
-    const resolverContract = this.buildContract(
-      resolverInterface,
-      resolver,
-    );
+    const resolver: string = await this.getResolver(tokenId);
+    const resolverContract = this.buildContract(resolverInterface, resolver);
     const record: string = await this.getRecord(resolverContract, 'get', [
       key.replace('.value', ''),
       tokenId,
@@ -208,10 +213,7 @@ export default class Cns extends EthereumNamingService {
         domain,
       });
     }
-    const resolverContract = this.buildContract(
-      resolverInterface,
-      resolver,
-    );
+    const resolverContract = this.buildContract(resolverInterface, resolver);
     const ttl = await this.getTtl(resolverContract, 'get', ['ttl', tokenId]);
     return [tokenId, owner, parseInt(ttl) || 0, resolver];
   }

--- a/src/namingService.ts
+++ b/src/namingService.ts
@@ -5,7 +5,7 @@ import {
   BlockhanNetworkUrlMap,
   ResolutionResponse,
   IPFS,
-  WHOIS
+  WHOIS,
 } from './types';
 import { hash } from 'eth-ens-namehash';
 import ResolutionError, { ResolutionErrorCode } from './resolutionError';
@@ -174,7 +174,7 @@ export abstract class EthereumNamingService extends NamingService {
     }
   }
 
-   buildContract(abi, address) {
-    return new Contract(this.name, this.url, abi, address)
+  buildContract(abi, address) {
+    return new Contract(this.name, this.url, abi, address);
   }
 }

--- a/src/namingService.ts
+++ b/src/namingService.ts
@@ -4,6 +4,8 @@ import {
   NetworkIdMap,
   BlockhanNetworkUrlMap,
   ResolutionResponse,
+  IPFS,
+  WHOIS
 } from './types';
 import { hash } from 'eth-ens-namehash';
 import ResolutionError, { ResolutionErrorCode } from './resolutionError';
@@ -26,6 +28,8 @@ export default abstract class NamingService extends BaseConnection {
   abstract owner(domain: string): Promise<string>;
   abstract record(domain: string, key: string): Promise<string>;
   abstract resolve(domain: string): Promise<ResolutionResponse>;
+  abstract ipfs(domain: string): Promise<IPFS>;
+  abstract whois(domain: string): Promise<WHOIS>;
 
   serviceName(domain: string): string {
     return this.name;
@@ -170,7 +174,7 @@ export abstract class EthereumNamingService extends NamingService {
     }
   }
 
-  protected buildContract(abi, address) {
+   buildContract(abi, address) {
     return new Contract(this.name, this.url, abi, address)
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,20 @@ export type Bip44Constants = [number, string, string];
 export type owner = string;
 export type ttl = string;
 
+export interface IPFS {
+  hash?: string,
+  redirect?: string
+};
+
+export interface WHOIS {
+  email?: string,
+  url ?: string,
+  avatar ?: string,
+  description ?: string,
+  notice ?: string,
+  for_sale ?: boolean
+}
+
 export enum NullAddress {
  '0x',
  '0x0000000000000000000000000000000000000000',
@@ -134,3 +148,6 @@ export const UnclaimedDomainResponse: ResolutionResponse = {
  * @deprecated Use UnclaimedDomainResponse instead (deprecated since 0.3.4)
  */
 export const UNCLAIMED_DOMAIN_RESPONSE = UnclaimedDomainResponse;
+
+
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,7 @@ export type NetworkIdMap = {
   [key: number]: string;
 };
 
-export const UDApiDefaultUrl = "https://unstoppabledomains.com/api/v1";
+export const UDApiDefaultUrl = 'https://unstoppabledomains.com/api/v1';
 
 /**
  * Main configurational object for Resolution instance
@@ -88,11 +88,11 @@ export type Blockchain =
     };
 
 export type API = {
-  url: string
-}
+  url: string;
+};
 
-export const DefaultAPI:API = {
-  url: UDApiDefaultUrl
+export const DefaultAPI: API = {
+  url: UDApiDefaultUrl,
 };
 
 /**
@@ -110,24 +110,24 @@ export type owner = string;
 export type ttl = string;
 
 export interface IPFS {
-  hash?: string,
-  redirect?: string
-};
+  hash?: string;
+  redirect?: string;
+}
 
 export interface WHOIS {
-  email?: string,
-  url ?: string,
-  avatar ?: string,
-  description ?: string,
-  notice ?: string,
-  for_sale ?: boolean
+  email?: string;
+  url?: string;
+  avatar?: string;
+  description?: string;
+  notice?: string;
+  for_sale?: boolean;
 }
 
 export enum NullAddress {
- '0x',
- '0x0000000000000000000000000000000000000000',
- '0x0000000000000000000000000000000000000000000000000000000000000000'
-};
+  '0x',
+  '0x0000000000000000000000000000000000000000',
+  '0x0000000000000000000000000000000000000000000000000000000000000000',
+}
 
 export function isNullAddress(key: string): boolean {
   return Object.values(NullAddress).includes(key);
@@ -148,6 +148,3 @@ export const UnclaimedDomainResponse: ResolutionResponse = {
  * @deprecated Use UnclaimedDomainResponse instead (deprecated since 0.3.4)
  */
 export const UNCLAIMED_DOMAIN_RESPONSE = UnclaimedDomainResponse;
-
-
-

--- a/src/unstoppableAPI.ts
+++ b/src/unstoppableAPI.ts
@@ -7,6 +7,8 @@ import {
   NamingServiceSource,
   SourceDefinition,
   isNullAddress,
+  IPFS,
+  WHOIS,
 } from './types';
 import Zns from './zns';
 import Ens from './ens';
@@ -39,6 +41,13 @@ export default class Udapi extends NamingService {
   /** @internal */
   isSupportedNetwork(): boolean {
     return true;
+  }
+
+  ipfs(domain: string): Promise<IPFS> {
+    return this.findMethodOrThrow(domain).ipfs(domain);
+  }
+  whois(domain: string): Promise<WHOIS> {
+    return this.findMethodOrThrow(domain).whois(domain);
   }
 
   /** @internal */

--- a/src/unstoppableAPI.ts
+++ b/src/unstoppableAPI.ts
@@ -26,7 +26,7 @@ export default class Udapi extends NamingService {
     const DefaultUserAgent = this.isNode()
       ? 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)'
       : navigator.userAgent;
-    const version = "1.0.9";
+    const version = '1.0.9';
     const CustomUserAgent = `${DefaultUserAgent} Resolution/${version}`;
     this.headers = { 'X-user-agent': CustomUserAgent };
   }
@@ -114,7 +114,9 @@ export default class Udapi extends NamingService {
   }
 
   private findMethod(domain: string) {
-    return [new Zns(), new Ens(), new Cns()].find(m => m.isSupportedDomain(domain));
+    return [new Zns(), new Ens(), new Cns()].find(m =>
+      m.isSupportedDomain(domain),
+    );
   }
 
   private findMethodOrThrow(domain: string) {

--- a/src/zns.ts
+++ b/src/zns.ts
@@ -62,7 +62,7 @@ export default class Zns extends NamingService {
   constructor(source: string | boolean | SourceDefinition = true) {
     super();
     source = this.normalizeSource(source);
-    this.name = "ZNS";
+    this.name = 'ZNS';
     this.network = source.network as string;
     this.url = source.url;
     if (!this.network) {
@@ -135,25 +135,26 @@ export default class Zns extends NamingService {
 
   async ipfs(domain: string): Promise<IPFS> {
     const records = await this.records(domain);
-    const hash = this.getRecordFieldOrThrow(
-      domain,
-      records,
-      'ipfs.html.value',
-    );
+    const hash = this.getRecordFieldOrThrow(domain, records, 'ipfs.html.value');
     const redirect = this.getRecordFieldOrThrow(
       domain,
       records,
       'ipfs.redirect_domain.value',
-    ); 
-    return {hash, redirect};
+    );
+    return { hash, redirect };
   }
 
   async whois(domain: string): Promise<WHOIS> {
     const records = await this.records(domain);
     const email = this.getRecordField(domain, records, 'whois.email.value');
-    const url = this.getRecordField(domain, records, 'ipfs.redirect_domain.value');
-    const for_sale = this.getRecordField(domain, records, 'whois.for_sale.value') || false;
-    return {email, url, for_sale: !!for_sale};
+    const url = this.getRecordField(
+      domain,
+      records,
+      'ipfs.redirect_domain.value',
+    );
+    const for_sale =
+      this.getRecordField(domain, records, 'whois.for_sale.value') || false;
+    return { email, url, for_sale: !!for_sale };
   }
 
   /**
@@ -207,7 +208,8 @@ export default class Zns extends NamingService {
    */
   isSupportedDomain(domain: string): boolean {
     return (
-      (domain.indexOf('.') > 0 && /^[a-zA-Z0-9].{1,}[^-]\.(zil)$/.test(domain)) ||
+      (domain.indexOf('.') > 0 &&
+        /^[a-zA-Z0-9].{1,}[^-]\.(zil)$/.test(domain)) ||
       domain === 'zil'
     );
   }
@@ -261,15 +263,18 @@ export default class Zns extends NamingService {
     }
   }
 
-  private getRecordField(domain: string, records: Dictionary<string>, field: string): string {
+  private getRecordField(
+    domain: string,
+    records: Dictionary<string>,
+    field: string,
+  ): string {
     try {
       return this.getRecordFieldOrThrow(domain, records, field);
-    } catch(err) {
-      if (err instanceof ResolutionError)
-        return undefined;
+    } catch (err) {
+      if (err instanceof ResolutionError) return undefined;
       throw err;
     }
-  };
+  }
 
   private getRecordFieldOrThrow(
     domain: string,


### PR DESCRIPTION
Introducing Resolution#ipfs and Resolution#whois. Methods to get the IPFS and whois metada respectively

Depricated Resolution#ipfsHash Resolution#ipfsRedirect Resolution#email and Zns#Resolution.

Zns#Resolution is now Zns#resolution.

I am lacking the test information on cns, the current one is not valid anymore. 