### PR TITLE
deprecate Resolution#address, Resolution#addressOrThrow, UnspecifiedCurrencyErrorCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+* Deprecated Resolution#address Resolution#addressOrThrow ResolutionErrorCode.UnspecifiedCurrency
 
 ## 1.6.1
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Example:
 const { Resolution } = require('@unstoppabledomains/resolution');
 
 const resolution = new Resolution();
-resolution.address('resolver.crypto', "ETH")
+resolution.addr('resolver.crypto', "ETH")
     .then(console.log)
     .catch(console.error);
 ```

--- a/src/Cns.test.ts
+++ b/src/Cns.test.ts
@@ -112,7 +112,7 @@ describe('CNS', () => {
           values: ['qzx048ez005q4yhphqu2pylpfc3hy88zzu4lu6q9j8'],
         },
       });
-      const addr = await resolution.address(
+      const addr = await resolution.addr(
         CryptoDomainWithAdaBchAddresses,
         'BCH',
       );
@@ -129,7 +129,7 @@ describe('CNS', () => {
           ],
         },
       });
-      const addr = await resolution.address(
+      const addr = await resolution.addr(
         CryptoDomainWithAdaBchAddresses,
         'ADA',
       );
@@ -339,7 +339,7 @@ describe('CNS', () => {
           values: ['0x8aaD44321A86b170879d7A244c1e8d360c99DdA8'],
         },
       });
-      const address = await resolution.address('brad.crypto', 'eth');
+      const address = await resolution.addr('brad.crypto', 'eth');
       expectSpyToBeCalled(eyes);
       expect(address).toBe('0x8aaD44321A86b170879d7A244c1e8d360c99DdA8');
     });
@@ -351,7 +351,7 @@ describe('CNS', () => {
           values: ['qzx048ez005q4yhphqu2pylpfc3hy88zzu4lu6q9j8'],
         },
       });
-      const addr = await resolution.address(
+      const addr = await resolution.addr(
         CryptoDomainWithAdaBchAddresses,
         'BCH',
       );
@@ -368,7 +368,7 @@ describe('CNS', () => {
           ],
         },
       });
-      const addr = await resolution.address(
+      const addr = await resolution.addr(
         CryptoDomainWithAdaBchAddresses,
         'ADA',
       );
@@ -521,7 +521,7 @@ describe('CNS', () => {
         });
 
         await expectResolutionErrorCode(
-          resolution.cns!.address('unregistered.crypto', 'ETH'),
+          resolution.cns!.addr('unregistered.crypto', 'ETH'),
           ResolutionErrorCode.UnregisteredDomain,
         );
         expectSpyToBeCalled(eyes);

--- a/src/Cns.ts
+++ b/src/Cns.ts
@@ -86,27 +86,6 @@ export default class Cns extends EthereumNamingService {
     throw new Error('This method is unsupported for CNS');
   }
 
-  /** @depricated since Resolution v1.6.2*/
-  async address(domain: string, currencyTicker: string): Promise<string> {
-    const tokenId = this.namehash(domain);
-
-    const reader = await this.getReader();
-    const key = `crypto.${currencyTicker.toUpperCase()}.address`;
-    const data = await reader.record(tokenId, key);
-    await this.verify(domain, data);
-
-    const { values } = data;
-    const value: string | null = values?.length ? values[0] : null;
-    if (!value) {
-      throw new ResolutionError(ResolutionErrorCode.UnspecifiedCurrency, {
-        domain,
-        currencyTicker,
-      });
-    }
-
-    return value;
-  }
-
   async addr(domain: string, currencyTicker: string): Promise<string> {
     const key = `crypto.${currencyTicker.toUpperCase()}.address`;
     return await this.record(domain, key);

--- a/src/Cns.ts
+++ b/src/Cns.ts
@@ -86,6 +86,7 @@ export default class Cns extends EthereumNamingService {
     throw new Error('This method is unsupported for CNS');
   }
 
+  /** @depricated since Resolution v1.6.2*/
   async address(domain: string, currencyTicker: string): Promise<string> {
     const tokenId = this.namehash(domain);
 
@@ -104,6 +105,11 @@ export default class Cns extends EthereumNamingService {
     }
 
     return value;
+  }
+
+  async addr(domain: string, currencyTicker: string): Promise<string> {
+    const key = `crypto.${currencyTicker.toUpperCase()}.address`;
+    return await this.record(domain, key);
   }
 
   async owner(domain: string): Promise<string> {
@@ -163,8 +169,8 @@ export default class Cns extends EthereumNamingService {
   }
 
   protected async getResolver(tokenId: string): Promise<string> {
-    return await this.ignoreResolutionError(
-      ResolutionErrorCode.RecordNotFound,
+    return await this.ignoreResolutionErrors(
+      [ResolutionErrorCode.RecordNotFound],
       this.callMethod(this.registryContract, 'resolverOf', [tokenId]),
     );
   }

--- a/src/Ens.test.ts
+++ b/src/Ens.test.ts
@@ -53,7 +53,7 @@ describe('ENS', () => {
       fetchAddressOrThrow: '0x714ef33943d925731FBB89C99aF5780D888bD106',
     });
 
-    expect(await resolution.address('matthewgould.eth', 'ETH')).toEqual(
+    expect(await resolution.addr('matthewgould.eth', 'ETH')).toEqual(
       '0x714ef33943d925731FBB89C99aF5780D888bD106',
     );
     expect(await resolution.owner('matthewgould.eth')).toEqual(
@@ -93,7 +93,7 @@ describe('ENS', () => {
       fetchAddressOrThrow: '0xb0E7a465D255aE83eb7F8a50504F3867B945164C',
     });
 
-    const result = await resolution.address('adrian.argent.xyz', 'ETH');
+    const result = await resolution.addr('adrian.argent.xyz', 'ETH');
     expectSpyToBeCalled(eyes);
     expect(result).toEqual('0xb0E7a465D255aE83eb7F8a50504F3867B945164C');
   });
@@ -105,7 +105,7 @@ describe('ENS', () => {
       fetchAddressOrThrow: '0xf3dE750A73C11a6a2863761E930BF5fE979d5663',
     });
 
-    const result = await resolution.address('john.luxe', 'ETH');
+    const result = await resolution.addr('john.luxe', 'ETH');
     expectSpyToBeCalled(eyes);
     expect(result).toEqual('0xf3dE750A73C11a6a2863761E930BF5fE979d5663');
   });
@@ -115,16 +115,9 @@ describe('ENS', () => {
       getResolver: '0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8',
       callMethod: '0x96184444629F3489c4dE199871E6F99568229d8f',
     });
-    const result = await resolution.address('brantly.kred', 'ETH');
+    const result = await resolution.addr('brantly.kred', 'ETH');
     expectSpyToBeCalled(eyes);
     expect(result).toEqual('0x96184444629F3489c4dE199871E6F99568229d8f');
-  });
-
-  it('resolves .luxe name using ENS blockchain with safe null return', async () => {
-    const ownerEye = mockAsyncMethod(resolution.ens, 'getOwner', NullAddress);
-    const result = await resolution.address('something.luxe', 'ETH');
-    expectSpyToBeCalled([ownerEye]);
-    expect(result).toEqual(null);
   });
 
   it('resolves .luxe name using ENS blockchain with thrown error', async () => {
@@ -134,7 +127,7 @@ describe('ENS', () => {
     });
 
     await expectResolutionErrorCode(
-      resolution.addressOrThrow('something.luxe', 'ETH'),
+      resolution.addr('something.luxe', 'ETH'),
       ResolutionErrorCode.UnregisteredDomain,
     );
     expectSpyToBeCalled(spies);
@@ -146,7 +139,7 @@ describe('ENS', () => {
       getResolver: '0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8',
       callMethod: '0x76a9144620b70031f0e9437e374a2100934fba4911046088ac',
     });
-    const doge = await resolution.ens!.address('testthing.eth', 'DOGE');
+    const doge = await resolution.ens!.addr('testthing.eth', 'DOGE');
     expectSpyToBeCalled(eyes);
     expect(doge).toBe('DBXu2kgc3xtvCUWFcxFE3r9hEYgmuaaCyD');
   });
@@ -291,7 +284,7 @@ describe('ENS', () => {
       getResolver: '0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8',
       callMethod: '0x76a9144620b70031f0e9437e374a2100934fba4911046088ac',
     });
-    const doge = await resolution.ens!.address('testthing.eth', 'DOGE');
+    const doge = await resolution.ens!.addr('testthing.eth', 'DOGE');
     expectSpyToBeCalled(eyes);
     expect(doge).toBe('DBXu2kgc3xtvCUWFcxFE3r9hEYgmuaaCyD');
   });
@@ -302,7 +295,7 @@ describe('ENS', () => {
       getResolver: '0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8',
       callMethod: '0xa914e8604d28ef5d2a7caafe8741e5dd4816b7cb19ea87',
     });
-    const ltc = await resolution.ens!.address('testthing.eth', 'LTC');
+    const ltc = await resolution.ens!.addr('testthing.eth', 'LTC');
     expectSpyToBeCalled(eyes);
     expect(ltc).toBe('MV5rN5EcX1imDS2gEh5jPJXeiW5QN8YrK3');
   });
@@ -313,7 +306,7 @@ describe('ENS', () => {
       getResolver: '0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8',
       callMethod: '0x314159265dd8dbb310642f98f50c066173c1259b',
     });
-    const eth = await resolution.ens!.address('testthing.eth', 'ETH');
+    const eth = await resolution.ens!.addr('testthing.eth', 'ETH');
     expectSpyToBeCalled(eyes);
     expect(eth).toBe('0x314159265dD8dbb310642f98f50C066173C1259b');
   });
@@ -324,7 +317,7 @@ describe('ENS', () => {
       getResolver: '0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8',
       callMethod: '0x314159265dd8dbb310642f98f50c066173c1259b',
     });
-    const etc = await resolution.ens!.address('testthing.eth', 'etc');
+    const etc = await resolution.ens!.addr('testthing.eth', 'etc');
     expectSpyToBeCalled(eyes);
     expect(etc).toBe('0x314159265dD8dbb310642f98f50C066173C1259b');
   });
@@ -335,7 +328,7 @@ describe('ENS', () => {
       getResolver: '0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8',
       callMethod: '0x314159265dd8dbb310642f98f50c066173c1259b',
     });
-    const rsk = await resolution.ens!.address('testthing.eth', 'rsk');
+    const rsk = await resolution.ens!.addr('testthing.eth', 'rsk');
     expectSpyToBeCalled(eyes);
     expect(rsk).toBe('0x314159265dD8DbB310642F98f50C066173c1259B');
   });
@@ -347,7 +340,7 @@ describe('ENS', () => {
       callMethod:
         '0x05444b4e9c06f24296074f7bc48f92a97916c6dc5ea9000000000000000000',
     });
-    const xrp = await resolution.ens!.address('testthing.eth', 'xrp');
+    const xrp = await resolution.ens!.addr('testthing.eth', 'xrp');
     expectSpyToBeCalled(eyes);
     expect(xrp).toBe('X7qvLs7gSnNoKvZzNWUT2e8st17QPY64PPe7zriLNuJszeg');
   });
@@ -358,7 +351,7 @@ describe('ENS', () => {
       getResolver: '0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8',
       callMethod: '0x76a91476a04053bda0a88bda5177b86a15c3b29f55987388ac',
     });
-    const bch = await resolution.ens!.address('testthing.eth', 'bch');
+    const bch = await resolution.ens!.addr('testthing.eth', 'bch');
     expectSpyToBeCalled(eyes);
     expect(bch).toBe('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a');
   });
@@ -370,7 +363,7 @@ describe('ENS', () => {
       callMethod:
         '0x5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6',
     });
-    const btc = await resolution.ens!.address('testthing.eth', 'BTC');
+    const btc = await resolution.ens!.addr('testthing.eth', 'BTC');
     expectSpyToBeCalled(eyes);
     expect(btc).toBe(
       'bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx',
@@ -382,7 +375,7 @@ describe('ENS', () => {
       getResolver: '0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8',
     });
     await expectResolutionErrorCode(
-      resolution.addressOrThrow('testthing.eth', 'bnb'),
+      resolution.addr('testthing.eth', 'bnb'),
       ResolutionErrorCode.UnsupportedCurrency,
     );
     expectSpyToBeCalled(eyes);
@@ -393,7 +386,7 @@ describe('ENS', () => {
       getResolver: '0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8',
     });
     await expectResolutionErrorCode(
-      resolution.addressOrThrow('testthing.eth', 'UNREALTICKER'),
+      resolution.addr('testthing.eth', 'UNREALTICKER'),
       ResolutionErrorCode.UnsupportedCurrency,
     );
     expectSpyToBeCalled(eyes);
@@ -439,19 +432,6 @@ describe('ENS', () => {
           ttl: 0,
         },
       });
-    });
-
-    it('resolve to null for empty .eth record', async () => {
-      expect(resolution.ens!.url).toBe(protocolLink());
-      expect(resolution.ens!.network).toEqual(1);
-
-      const eyes = mockAsyncMethods(resolution.ens, {
-        getOwner: '0x714ef33943d925731FBB89C99aF5780D888bD106',
-        getResolver: '0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8',
-      });
-
-      expect(await resolution.address('qwdqwd.eth', 'XRP')).toEqual(null);
-      expectSpyToBeCalled(eyes);
     });
 
     it('should return correct resolver address', async () => {

--- a/src/NamingService.ts
+++ b/src/NamingService.ts
@@ -39,9 +39,6 @@ export default abstract class NamingService extends BaseConnection {
   abstract allRecords(domain: string): Promise<Record<string, string>>;
   abstract addr(domain: string, currencyTicker: string);
   
-  /** @depricated since Resolution v1.6.2 */
-  abstract address(domain: string, currencyTicker: string): Promise<string>;
-
   constructor(source: SourceDefinition, name: ResolutionMethod) {
     super();
     this.name = name;

--- a/src/NamingService.ts
+++ b/src/NamingService.ts
@@ -22,7 +22,6 @@ export default abstract class NamingService extends BaseConnection {
   protected provider: Provider;
   abstract isSupportedDomain(domain: string): boolean;
   abstract isSupportedNetwork(): boolean;
-  abstract address(domain: string, currencyTicker: string): Promise<string>;
   abstract owner(domain: string): Promise<string | null>;
   abstract record(domain: string, key: string): Promise<string>;
   abstract resolve(domain: string): Promise<ResolutionResponse | null>;
@@ -38,6 +37,10 @@ export default abstract class NamingService extends BaseConnection {
     options?: { prefix: boolean },
   ): nodeHash;
   abstract allRecords(domain: string): Promise<Record<string, string>>;
+  abstract addr(domain: string, currencyTicker: string);
+  
+  /** @depricated since Resolution v1.6.2 */
+  abstract address(domain: string, currencyTicker: string): Promise<string>;
 
   constructor(source: SourceDefinition, name: ResolutionMethod) {
     super();
@@ -83,14 +86,14 @@ export default abstract class NamingService extends BaseConnection {
     }
   }
 
-  protected async ignoreResolutionError<T>(
-    code: ResolutionErrorCode | undefined,
+  protected async ignoreResolutionErrors<T>(
+    codes: (ResolutionErrorCode)[],
     promise: Promise<T>,
   ): Promise<T | undefined> {
     try {
       return await promise;
     } catch (error) {
-      if (this.isResolutionError(error, code)) {
+      if (codes.every((code) => this.isResolutionError(error, code))) {
         return undefined;
       } else {
         throw error;

--- a/src/Resolution.test.ts
+++ b/src/Resolution.test.ts
@@ -45,7 +45,7 @@ describe('Resolution', () => {
     expect(resolution.cns!.url).toBe(`https://mainnet.infura.com/v3/api-key`);
   });
 
-  it('checks Resolution#addressOrThrow error #1', async () => {
+  it('checks Resolution#addr error #1', async () => {
     const resolution = new Resolution();
     await expectResolutionErrorCode(
       resolution.addr('sdncdoncvdinvcsdncs.zil', 'ZIL'),

--- a/src/Resolution.test.ts
+++ b/src/Resolution.test.ts
@@ -48,31 +48,17 @@ describe('Resolution', () => {
   it('checks Resolution#addressOrThrow error #1', async () => {
     const resolution = new Resolution();
     await expectResolutionErrorCode(
-      resolution.addressOrThrow('sdncdoncvdinvcsdncs.zil', 'ZIL'),
+      resolution.addr('sdncdoncvdinvcsdncs.zil', 'ZIL'),
       ResolutionErrorCode.UnregisteredDomain,
-    );
-  });
-
-  it('checks Resolution#addressOrThrow error #2', async () => {
-    const resolution = new Resolution();
-    await expectResolutionErrorCode(
-      resolution.addressOrThrow('brad.zil', 'INVALID_CURRENCY_SYMBOL'),
-      ResolutionErrorCode.UnspecifiedCurrency,
     );
   });
 
   it('resolves non-existing domain zone with throw', async () => {
     const resolution = new Resolution({ blockchain: true });
     await expectResolutionErrorCode(
-      resolution.addressOrThrow('bogdangusiev.qq', 'ZIL'),
+      resolution.addr('bogdangusiev.qq', 'ZIL'),
       ResolutionErrorCode.UnsupportedDomain,
     );
-  });
-
-  it('resolves non-existing domain zone via safe address', async () => {
-    const resolution = new Resolution({ blockchain: true });
-    const result = await resolution.address('bogdangusiev.qq', 'ZIL');
-    expect(result).toEqual(null);
   });
 
   it('provides empty response constant', async () => {
@@ -182,9 +168,9 @@ describe('Resolution', () => {
         values: ['0x45b31e01AA6f42F0549aD482BE81635ED3149abb'],
       },
     });
-    const capital = await resolution.addressOrThrow('Brad.crypto', 'eth');
+    const capital = await resolution.addr('Brad.crypto', 'eth');
     expectSpyToBeCalled(eyes);
-    const lower = await resolution.addressOrThrow('brad.crypto', 'eth');
+    const lower = await resolution.addr('brad.crypto', 'eth');
     expectSpyToBeCalled(eyes);
     expect(capital).toStrictEqual(lower);
   });
@@ -336,7 +322,7 @@ describe('Resolution', () => {
         },
       );
       const resolution = Resolution.fromWeb3Version1Provider(provider);
-      const ethAddress = await resolution.addressOrThrow('brad.crypto', 'ETH');
+      const ethAddress = await resolution.addr('brad.crypto', 'ETH');
 
       // expect each mock to be called at least once.
       expectSpyToBeCalled([eye]);
@@ -359,7 +345,7 @@ describe('Resolution', () => {
       });
 
       const resolution = Resolution.fromWeb3Version1Provider(provider);
-      const ethAddress = await resolution.addressOrThrow('brad.crypto', 'ETH');
+      const ethAddress = await resolution.addr('brad.crypto', 'ETH');
       provider.disconnect(1000, 'end of test');
       expectSpyToBeCalled([eye]);
       expect(ethAddress).toBe('0x8aaD44321A86b170879d7A244c1e8d360c99DdA8');
@@ -374,7 +360,7 @@ describe('Resolution', () => {
       const eye = mockAsyncMethod(provider, 'call', params =>
         Promise.resolve(caseMock(params, RpcProviderTestCases)),
       );
-      const ethAddress = await resolution.addressOrThrow('brad.crypto', 'ETH');
+      const ethAddress = await resolution.addr('brad.crypto', 'ETH');
       expectSpyToBeCalled([eye]);
       expect(ethAddress).toBe('0x8aaD44321A86b170879d7A244c1e8d360c99DdA8');
     });
@@ -386,7 +372,7 @@ describe('Resolution', () => {
         Promise.resolve(caseMock(params, RpcProviderTestCases)),
       );
       const resolution = Resolution.fromEthersProvider(provider);
-      const ethAddress = await resolution.addressOrThrow('brad.crypto', 'eth');
+      const ethAddress = await resolution.addr('brad.crypto', 'eth');
       expectSpyToBeCalled([eye]);
       expect(ethAddress).toBe('0x8aaD44321A86b170879d7A244c1e8d360c99DdA8');
     });
@@ -412,7 +398,7 @@ describe('Resolution', () => {
         },
       );
       const resolution = Resolution.fromWeb3Version0Provider(provider);
-      const ethAddress = await resolution.addressOrThrow('brad.crypto', 'eth');
+      const ethAddress = await resolution.addr('brad.crypto', 'eth');
       expectSpyToBeCalled([eye]);
       expect(ethAddress).toBe('0x8aaD44321A86b170879d7A244c1e8d360c99DdA8');
     });

--- a/src/Resolution.ts
+++ b/src/Resolution.ts
@@ -296,7 +296,14 @@ export default class Resolution {
     );
     domain = this.prepareDomain(domain);
     const method = this.getNamingMethodOrThrow(domain);
-    return await method.address(domain, currencyTicker);
+    try {
+      return await method.addr(domain, currencyTicker);
+    } catch(error) {
+      if (error instanceof ResolutionError && error.code === ResolutionErrorCode.RecordNotFound) {
+        throw new ResolutionError(ResolutionErrorCode.UnspecifiedCurrency, {domain, currencyTicker});
+      }
+      throw error;
+    }
   }
 
   /**

--- a/src/Resolution.ts
+++ b/src/Resolution.ts
@@ -168,12 +168,16 @@ export default class Resolution {
    * @async
    * @param domain - domain name to be resolved
    * @param currencyTicker - currency ticker like BTC, ETH, ZIL
+   * @depricated since Resolution v1.6.2
    * @returns A promise that resolves in an address or null
    */
   async address(
     domain: string,
     currencyTicker: string,
   ): Promise<string | null> {
+    console.warn(
+      'Resolution#address is depricated since 1.6.2, use Resolution#addr instead',
+    );
     domain = this.prepareDomain(domain);
     try {
       return await this.addressOrThrow(domain, currencyTicker);
@@ -184,6 +188,22 @@ export default class Resolution {
         throw error;
       }
     }
+  }
+
+ /**
+   * Resolves give domain name to a specific currency address if exists
+   * @async
+   * @param domain - domain name to be resolved
+   * @param currencyTicker - currency ticker like BTC, ETH, ZIL
+   * @throws [[ResolutionError]] if address is not found 
+   * @returns A promise that resolves in an address
+   */ 
+  async addr(
+    domain: string,
+    currrencyTicker: string,
+  ): Promise<string> {
+    domain = this.prepareDomain(domain);
+    return await this.getNamingMethodOrThrow(domain).addr(domain, currrencyTicker);
   }
 
   /**
@@ -265,11 +285,15 @@ export default class Resolution {
    *  - BTC
    *  - ETH
    * @throws [[ResolutionError]] if address is not found
+   * @depricated use Resolution.addr instead
    */
   async addressOrThrow(
     domain: string,
     currencyTicker: string,
   ): Promise<string> {
+    console.warn(
+      'Resolution#addressOrThrow is depricated since 1.6.2, use Resolution#addr instead',
+    );
     domain = this.prepareDomain(domain);
     const method = this.getNamingMethodOrThrow(domain);
     return await method.address(domain, currencyTicker);

--- a/src/Resolution.ts
+++ b/src/Resolution.ts
@@ -302,7 +302,7 @@ export default class Resolution {
     } catch(error) {
       // re-throw an error for back compatability. New method.addr throws deprecated UnspecifiedCurrency code since v1.6.2
       if (error instanceof ResolutionError && error.code === ResolutionErrorCode.RecordNotFound) {
-        throw new ResolutionError(ResolutionErrorCode.UnspecifiedCurrency, {domain, currencyTicker});
+        throw new ResolutionError(ResolutionErrorCode.UnspecifiedCurrency, {domain, currencyTicker, deprecated: true});
       }
       throw error;
     }

--- a/src/Resolution.ts
+++ b/src/Resolution.ts
@@ -178,6 +178,7 @@ export default class Resolution {
     console.warn(
       'Resolution#address is depricated since 1.6.2, use Resolution#addr instead',
     );
+    // throw new Error("just temp");
     domain = this.prepareDomain(domain);
     try {
       return await this.addressOrThrow(domain, currencyTicker);
@@ -299,6 +300,7 @@ export default class Resolution {
     try {
       return await method.addr(domain, currencyTicker);
     } catch(error) {
+      // re-throw an error for back compatability. New method.addr throws deprecated UnspecifiedCurrency code since v1.6.2
       if (error instanceof ResolutionError && error.code === ResolutionErrorCode.RecordNotFound) {
         throw new ResolutionError(ResolutionErrorCode.UnspecifiedCurrency, {domain, currencyTicker});
       }

--- a/src/Resolution.ts
+++ b/src/Resolution.ts
@@ -37,7 +37,7 @@ import { Eip1993Factories } from './utils/Eip1993Factories';
  *   });
  *
  * let domain = "brad.zil";
- * resolution.address(domain, "eth").then(addr => console.log(addr));;
+ * resolution.addr(domain, "eth").then(addr => console.log(addr));;
  * ```
  */
 export default class Resolution {
@@ -285,7 +285,7 @@ export default class Resolution {
    *  - BTC
    *  - ETH
    * @throws [[ResolutionError]] if address is not found
-   * @depricated use Resolution.addr instead
+   * @depricated since v1.6.2 use Resolution.addr instead
    */
   async addressOrThrow(
     domain: string,

--- a/src/UdApi.test.ts
+++ b/src/UdApi.test.ts
@@ -17,7 +17,7 @@ describe('Unstoppable API', () => {
   it('resolves a domain', async () => {
     mockAPICalls('ud_api_generic_test', DefaultUrl);
     const resolution = new Resolution({ blockchain: false });
-    const result = await resolution.address('cofounding.zil', 'eth');
+    const result = await resolution.addr('cofounding.zil', 'eth');
     expect(result).toEqual('0xaa91734f90795e80751c96e682a321bb3c1a4186');
   });
   it('namehashes zil domain', async () => {

--- a/src/UdApi.ts
+++ b/src/UdApi.ts
@@ -11,6 +11,8 @@ import Zns from './Zns';
 import Ens from './Ens';
 import Cns from './Cns';
 import pckg from './package.json';
+import Resolution from './Resolution';
+import { EEXIST } from 'constants';
 
 /** @internal */
 export default class Udapi extends NamingService {
@@ -40,23 +42,37 @@ export default class Udapi extends NamingService {
     return this.findMethodOrThrow(domain).namehash(domain);
   }
 
+  /** @deprecated since Resolution v1.6.2
+   * use UDApi#addr instead
+   */
   async address(domain: string, currencyTicker: string): Promise<string> {
+    try {
+      return await this.addr(domain, currencyTicker)
+    } catch(error) {
+      if (this.isResolutionError(error, ResolutionErrorCode.RecordNotFound)) {
+        throw new ResolutionError(ResolutionErrorCode.UnspecifiedCurrency, {domain, currencyTicker});
+      }
+      throw error;
+    }
+  }
+
+  async addr(domain: string, currencyTicker: string): Promise<string> {
     const data = await this.resolve(domain);
     if (isNullAddress(data.meta.owner)) {
       throw new ResolutionError(ResolutionErrorCode.UnregisteredDomain, {
-        domain,
+        domain
       });
     }
     const address = data.addresses[currencyTicker.toUpperCase()];
     if (!address) {
-      throw new ResolutionError(ResolutionErrorCode.UnspecifiedCurrency, {
+      throw new ResolutionError(ResolutionErrorCode.RecordNotFound, {
         domain,
-        currencyTicker,
+        currencyTicker
       });
     }
     return address;
   }
-
+  
   async owner(domain: string): Promise<string | null> {
     const { owner } = (await this.resolve(domain)).meta;
     if (!owner) return null;

--- a/src/UdApi.ts
+++ b/src/UdApi.ts
@@ -11,8 +11,6 @@ import Zns from './Zns';
 import Ens from './Ens';
 import Cns from './Cns';
 import pckg from './package.json';
-import Resolution from './Resolution';
-import { EEXIST } from 'constants';
 
 /** @internal */
 export default class Udapi extends NamingService {
@@ -40,20 +38,6 @@ export default class Udapi extends NamingService {
 
   namehash(domain: string): string {
     return this.findMethodOrThrow(domain).namehash(domain);
-  }
-
-  /** @deprecated since Resolution v1.6.2
-   * use UDApi#addr instead
-   */
-  async address(domain: string, currencyTicker: string): Promise<string> {
-    try {
-      return await this.addr(domain, currencyTicker)
-    } catch(error) {
-      if (this.isResolutionError(error, ResolutionErrorCode.RecordNotFound)) {
-        throw new ResolutionError(ResolutionErrorCode.UnspecifiedCurrency, {domain, currencyTicker});
-      }
-      throw error;
-    }
   }
 
   async addr(domain: string, currencyTicker: string): Promise<string> {

--- a/src/Zns.test.ts
+++ b/src/Zns.test.ts
@@ -153,16 +153,6 @@ describe('ZNS', () => {
       expect(result.meta.ttl).toEqual(0);
     });
 
-    it('resolves unclaimed domain using blockchain', async () => {
-      const spyes = mockAsyncMethods(resolution.zns, {
-        getRecordsAddresses: undefined,
-      });
-      const address = await resolution.address('test.zil', 'ETH');
-      expectSpyToBeCalled(spyes);
-      expect(address).toEqual(null);
-      expect(await resolution.owner('test.zil')).toEqual(null);
-    });
-
     it('resolves domain using blockchain #2', async () => {
       const spyes = mockAsyncMethods(resolution.zns, {
         getRecordsAddresses: [
@@ -242,24 +232,6 @@ describe('ZNS', () => {
       await expectResolutionErrorCode(
         resolution.zns!.resolver('paulalcock.zil'),
         ResolutionErrorCode.UnspecifiedResolver,
-      );
-      expectSpyToBeCalled(spies);
-    });
-
-    it('should resolve with UnspecifiedCurriency', async () => {
-      const spies = mockAsyncMethods(resolution.zns, {
-        getRecordsAddresses: [
-          'zil1thd3le9wdl3ashy7h4j4dm8slm8grausdm4nyr',
-          '0x2410f1f18062b9e6f03246ba126f1f02605b1837',
-        ],
-        getResolverRecords: {
-          'whois.email.value': 'alain974@protonmail.com',
-          'whois.for_sale.value': 'true',
-        },
-      });
-      await expectResolutionErrorCode(
-        resolution.addressOrThrow('macron2022.zil', 'btc'),
-        ResolutionErrorCode.UnspecifiedCurrency,
       );
       expectSpyToBeCalled(spies);
     });

--- a/src/Zns.ts
+++ b/src/Zns.ts
@@ -17,6 +17,7 @@ import {
 } from './types';
 import { ResolutionError, ResolutionErrorCode } from './index';
 import NamingService from './NamingService';
+import { add } from 'lodash';
 
 const DefaultSource = 'https://api.zilliqa.com';
 
@@ -67,7 +68,10 @@ export default class Zns extends NamingService {
       records: resolution.records,
     };
   }
-
+  
+/** @depricated since Resolution v1.6.2
+ * use Zns#addr instead
+*/
   async address(domain: string, currencyTicker: string): Promise<string> {
     const data = await this.resolve(domain);
     if (isNullAddress(data?.meta?.owner)) {
@@ -80,6 +84,23 @@ export default class Zns extends NamingService {
       throw new ResolutionError(ResolutionErrorCode.UnspecifiedCurrency, {
         domain,
         currencyTicker,
+      });
+    }
+    return address;
+  }
+
+  async addr(domain: string, currencyTicker:  string): Promise<string> {
+    const data = await this.resolve(domain);
+    if (isNullAddress(data?.meta?.owner)) {
+      throw new ResolutionError(ResolutionErrorCode.UnregisteredDomain, {
+        domain,
+      });
+    }
+    const address = data!.addresses[currencyTicker.toUpperCase()];
+    if (!address) {
+      throw new ResolutionError(ResolutionErrorCode.RecordNotFound, {
+        recordName: currencyTicker,
+        domain
       });
     }
     return address;

--- a/src/Zns.ts
+++ b/src/Zns.ts
@@ -69,26 +69,6 @@ export default class Zns extends NamingService {
     };
   }
   
-/** @depricated since Resolution v1.6.2
- * use Zns#addr instead
-*/
-  async address(domain: string, currencyTicker: string): Promise<string> {
-    const data = await this.resolve(domain);
-    if (isNullAddress(data?.meta?.owner)) {
-      throw new ResolutionError(ResolutionErrorCode.UnregisteredDomain, {
-        domain,
-      });
-    }
-    const address = data!.addresses[currencyTicker.toUpperCase()];
-    if (!address) {
-      throw new ResolutionError(ResolutionErrorCode.UnspecifiedCurrency, {
-        domain,
-        currencyTicker,
-      });
-    }
-    return address;
-  }
-
   async addr(domain: string, currencyTicker:  string): Promise<string> {
     const data = await this.resolve(domain);
     if (isNullAddress(data?.meta?.owner)) {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -95,7 +95,7 @@ import {
     options.currencies.forEach(async (currency:string) => {
       resolutionProcess.push(
         tryInfo(
-          async () => await resolution.addressOrThrow(domain, currency),
+          async () => await resolution.addr(domain, currency),
           response,
           currency,
         ),

--- a/src/ens/contract/resolver.ts
+++ b/src/ens/contract/resolver.ts
@@ -10,7 +10,7 @@ export const OldResolverAddresses = [
 ];
 
 
-export default (addr: string, coinType?: number) => {
+export default (addr: string, coinType?: string) => {
   if (coinType === undefined || coinType === EthCoinIndex) {
     // Old interface is only compatible to output the ETH address
     // New interface is compatible to that API

--- a/src/errors/resolutionError.ts
+++ b/src/errors/resolutionError.ts
@@ -3,6 +3,7 @@ import { ResolutionMethod } from '../types';
 type ResolutionErrorHandler = (error: ResolutionErrorOptions) => string;
 /** Explains Resolution Error options */
 type ResolutionErrorOptions = {
+  deprecated?: boolean;
   providerMessage?: string;
   method?: ResolutionMethod;
   domain?: string;
@@ -36,6 +37,7 @@ const HandlersByCode = {
   [ResolutionErrorCode.UnspecifiedCurrency]: (params: {
     domain: string;
     currencyTicker: string;
+    depecated: boolean;
   }) =>
     `Domain ${params.domain} has no ${params.currencyTicker} attached to it`,
   [ResolutionErrorCode.NamingServiceDown]: (params: {
@@ -79,7 +81,9 @@ export class ResolutionError extends Error {
   constructor(code: ResolutionErrorCode, options: ResolutionErrorOptions = {}) {
     const resolutionErrorHandler: ResolutionErrorHandler = HandlersByCode[code];
     const { domain, method, currencyTicker } = options;
-    super(resolutionErrorHandler(options));
+    let message = resolutionErrorHandler(options);
+    if (options.deprecated) {message += `\nResolutionErrorCode ${code} is deprecated and will be removed in the future`}
+    super(message);
     this.code = code;
     this.domain = domain;
     this.method = method;

--- a/src/types.ts
+++ b/src/types.ts
@@ -250,7 +250,7 @@ export function isNullAddress(
   return Object.values(NullAddresses).includes(key);
 }
 
-export const EthCoinIndex = 60;
+export const EthCoinIndex = "60";
 
 export const UnclaimedDomainResponse: ResolutionResponse = {
   addresses: {},


### PR DESCRIPTION
Currently, Resolution#address method doesn’t throw an exception when address is not found, while other methods do
There is an additional method addressOrThrow that does throw a ResolutionError, however with a UnspecifiedCurrency error code while other resolution methods throw RecordNotFound error code.

Solution:

* Introduce Resolution#addr method that would throw RecordNotFound error code when the address is not found
* Deprecate addressOrThrow, address, and UnspecifiedCurrency error code.

I removed the deprecated methods from our test coverage as well. It is backward compatible as of now, but we do not quarantine it in the future. 

To check backward compatibility the one can jump on commit 677c62f032e947ba704da0bcac3ab83d7f31b671 and verify that test by doing yarn test.  This is the 1 commit before I removed the test coverage from these methods.