### PR TITLE
Simple naming services

### DIFF
--- a/src/Cns.ts
+++ b/src/Cns.ts
@@ -119,26 +119,6 @@ export default class Cns extends EthereumNamingService {
     }
   }
 
-  async ipfsHash(domain: string): Promise<string> {
-    return await this.record(domain, 'ipfs.html.value');
-  }
-
-  async email(domain: string): Promise<string> {
-    return await this.record(domain, 'whois.email.value');
-  }
-
-  async chatId(domain: string): Promise<string> {
-    return await this.record(domain, 'gundb.username.value');
-  }
-
-  async chatpk(domain: string): Promise<string> {
-    return await this.record(domain, 'gundb.public_key.value');
-  }
-
-  async httpUrl(domain: string): Promise<string> {
-    return await this.record(domain, 'ipfs.redirect_domain.value');
-  }
-
   async allRecords(domain: string): Promise<Record<string, string>> {
     const tokenId = this.namehash(domain);
     const resolver = await this.resolver(domain);

--- a/src/Ens.ts
+++ b/src/Ens.ts
@@ -48,8 +48,8 @@ export default class Ens extends EthereumNamingService {
       const hash = await this.getContentHash(domain);
       return this.ensureRecordPresence(domain, 'IPFS hash', hash);
     }
-    const EnsRecordName = this.fromUDRecordNameToENS(key);
-    return await this.getTextRecord(domain, EnsRecordName);
+    const ensRecordName = this.fromUDRecordNameToENS(key);
+    return await this.getTextRecord(domain, ensRecordName);
   }
 
   private fromUDRecordNameToENS(record: string): string {

--- a/src/Ens.ts
+++ b/src/Ens.ts
@@ -42,23 +42,23 @@ export default class Ens extends EthereumNamingService {
   isSupportedNetwork(): boolean {
     return this.registryAddress != null;
   }
-  
+
   async record(domain: string, key: string): Promise<string> {
-    if (key === "ipfs.html.value") {
+    if (key === 'ipfs.html.value') {
       const hash = await this.getContentHash(domain);
       return this.ensureRecordPresence(domain, 'IPFS hash', hash);
     }
-    const EnsRecordName = this.fromUDRecordNameToENS(key)
+    const EnsRecordName = this.fromUDRecordNameToENS(key);
     return await this.getTextRecord(domain, EnsRecordName);
   }
 
-  private fromUDRecordNameToENS(record: string) : string {
+  private fromUDRecordNameToENS(record: string): string {
     const mapper = {
-      "ipfs.redirect_domain.value": "url",
-      "whois.email.value": "email",
-      "gundb.username.value": "gundb_username", 
-      "gundb.public_key.value": "gundb_public_key" 
-    }
+      'ipfs.redirect_domain.value': 'url',
+      'whois.email.value': 'email',
+      'gundb.username.value': 'gundb_username',
+      'gundb.public_key.value': 'gundb_public_key',
+    };
     return mapper[record] || record;
   }
 
@@ -130,8 +130,6 @@ export default class Ens extends EthereumNamingService {
     if (address) resolution.addresses = { ETH: address };
     return resolution;
   }
-
-
 
   async allRecords(domain: string): Promise<Record<string, string>> {
     throw new Error('Method not implemented.');

--- a/src/Ens.ts
+++ b/src/Ens.ts
@@ -42,9 +42,24 @@ export default class Ens extends EthereumNamingService {
   isSupportedNetwork(): boolean {
     return this.registryAddress != null;
   }
+  
+  async record(domain: string, key: string): Promise<string> {
+    if (key === "ipfs.html.value") {
+      const hash = await this.getContentHash(domain);
+      return this.ensureRecordPresence(domain, 'IPFS hash', hash);
+    }
+    const EnsRecordName = this.fromUDRecordNameToENS(key)
+    return await this.getTextRecord(domain, EnsRecordName);
+  }
 
-  record(domain: string, key: string): Promise<string> {
-    throw new Error('Method not implemented.');
+  private fromUDRecordNameToENS(record: string) : string {
+    const mapper = {
+      "ipfs.redirect_domain.value": "url",
+      "whois.email.value": "email",
+      "gundb.username.value": "gundb_username", 
+      "gundb.public_key.value": "gundb_public_key" 
+    }
+    return mapper[record] || record;
   }
 
   async reverse(
@@ -116,26 +131,7 @@ export default class Ens extends EthereumNamingService {
     return resolution;
   }
 
-  async ipfsHash(domain: string): Promise<string> {
-    const hash = await this.getContentHash(domain);
-    return this.ensureRecordPresence(domain, 'IPFS hash', hash);
-  }
 
-  async httpUrl(domain: string): Promise<string> {
-    return await this.getTextRecord(domain, 'url');
-  }
-
-  async email(domain: string): Promise<string> {
-    return await this.getTextRecord(domain, 'email');
-  }
-
-  async chatId(domain: string): Promise<string> {
-    return await this.getTextRecord(domain, 'gundb_username');
-  }
-
-  async chatpk(domain: string): Promise<string> {
-    return await this.getTextRecord(domain, 'gundb_public_key');
-  }
 
   async allRecords(domain: string): Promise<Record<string, string>> {
     throw new Error('Method not implemented.');

--- a/src/NamingService.ts
+++ b/src/NamingService.ts
@@ -26,12 +26,7 @@ export default abstract class NamingService extends BaseConnection {
   abstract owner(domain: string): Promise<string | null>;
   abstract record(domain: string, key: string): Promise<string>;
   abstract resolve(domain: string): Promise<ResolutionResponse | null>;
-  abstract ipfsHash(domain: string): Promise<string>;
-  abstract email(domain: string): Promise<string>;
-  abstract httpUrl(domain: string): Promise<string>;
   abstract resolver(domain: string): Promise<string>;
-  abstract chatId(domain: string): Promise<string>;
-  abstract chatpk(domain: string): Promise<string>;
   abstract childhash(
     parent: nodeHash,
     label: string,

--- a/src/Resolution.ts
+++ b/src/Resolution.ts
@@ -195,7 +195,7 @@ export default class Resolution {
   async chatId(domain: string): Promise<string> {
     domain = this.prepareDomain(domain);
     const method = this.getNamingMethodOrThrow(domain);
-    return await method.chatId(domain);
+    return await method.record(domain, 'gundb.username.value');
   }
 
   /**
@@ -207,7 +207,7 @@ export default class Resolution {
   async chatPk(domain: string): Promise<string> {
     domain = this.prepareDomain(domain);
     const method = this.getNamingMethodOrThrow(domain);
-    return await method.chatpk(domain);
+    return await method.record(domain, "gundb.public_key.value");
   }
 
   /**
@@ -217,7 +217,7 @@ export default class Resolution {
    */
   async ipfsHash(domain: string): Promise<string> {
     domain = this.prepareDomain(domain);
-    return await this.getNamingMethodOrThrow(domain).ipfsHash(domain);
+    return await this.getNamingMethodOrThrow(domain).record(domain, "ipfs.html.value");
   }
 
   /**
@@ -226,7 +226,7 @@ export default class Resolution {
    */
   async httpUrl(domain: string): Promise<string> {
     domain = this.prepareDomain(domain);
-    return await this.getNamingMethodOrThrow(domain).httpUrl(domain);
+    return await this.getNamingMethodOrThrow(domain).record(domain, 'ipfs.redirect_domain.value');
   }
 
   /**
@@ -254,7 +254,7 @@ export default class Resolution {
    */
   async email(domain: string): Promise<string> {
     domain = this.prepareDomain(domain);
-    return await this.getNamingMethodOrThrow(domain).email(domain);
+    return await this.getNamingMethodOrThrow(domain).record(domain, 'whois.email.value');
   }
 
   /**

--- a/src/Resolution.ts
+++ b/src/Resolution.ts
@@ -193,9 +193,7 @@ export default class Resolution {
    * @returns A promise that resolves in chatId
    */
   async chatId(domain: string): Promise<string> {
-    domain = this.prepareDomain(domain);
-    const method = this.getNamingMethodOrThrow(domain);
-    return await method.record(domain, 'gundb.username.value');
+    return await this.record(domain, 'gundb.username.value');
   }
 
   /**
@@ -205,9 +203,7 @@ export default class Resolution {
    * @returns a promise that resolves in gundb public key
    */
   async chatPk(domain: string): Promise<string> {
-    domain = this.prepareDomain(domain);
-    const method = this.getNamingMethodOrThrow(domain);
-    return await method.record(domain, 'gundb.public_key.value');
+    return await this.record(domain, 'gundb.public_key.value');
   }
 
   /**
@@ -216,11 +212,7 @@ export default class Resolution {
    * @throws [[ResolutionError]]
    */
   async ipfsHash(domain: string): Promise<string> {
-    domain = this.prepareDomain(domain);
-    return await this.getNamingMethodOrThrow(domain).record(
-      domain,
-      'ipfs.html.value',
-    );
+    return await this.record(domain, 'ipfs.html.value');
   }
 
   /**
@@ -228,11 +220,7 @@ export default class Resolution {
    * @param domain - domain name
    */
   async httpUrl(domain: string): Promise<string> {
-    domain = this.prepareDomain(domain);
-    return await this.getNamingMethodOrThrow(domain).record(
-      domain,
-      'ipfs.redirect_domain.value',
-    );
+    return await this.record(domain, 'ipfs.redirect_domain.value');
   }
 
   /**
@@ -246,10 +234,7 @@ export default class Resolution {
     console.warn(
       'Resolution#ipfsRedirect is depricated since 1.0.15, use Resolution#httpUrl instead',
     );
-    return await this.getNamingMethodOrThrow(domain).record(
-      domain,
-      'ipfs.redirect_domain.value',
-    );
+    return await this.record(domain, 'ipfs.redirect_domain.value');
   }
 
   /**
@@ -259,11 +244,7 @@ export default class Resolution {
    * @returns A Promise that resolves in an email address configured for this domain whois
    */
   async email(domain: string): Promise<string> {
-    domain = this.prepareDomain(domain);
-    return await this.getNamingMethodOrThrow(domain).record(
-      domain,
-      'whois.email.value',
-    );
+    return await this.record(domain, 'whois.email.value');
   }
 
   /**

--- a/src/Resolution.ts
+++ b/src/Resolution.ts
@@ -207,7 +207,7 @@ export default class Resolution {
   async chatPk(domain: string): Promise<string> {
     domain = this.prepareDomain(domain);
     const method = this.getNamingMethodOrThrow(domain);
-    return await method.record(domain, "gundb.public_key.value");
+    return await method.record(domain, 'gundb.public_key.value');
   }
 
   /**
@@ -217,7 +217,10 @@ export default class Resolution {
    */
   async ipfsHash(domain: string): Promise<string> {
     domain = this.prepareDomain(domain);
-    return await this.getNamingMethodOrThrow(domain).record(domain, "ipfs.html.value");
+    return await this.getNamingMethodOrThrow(domain).record(
+      domain,
+      'ipfs.html.value',
+    );
   }
 
   /**
@@ -226,7 +229,10 @@ export default class Resolution {
    */
   async httpUrl(domain: string): Promise<string> {
     domain = this.prepareDomain(domain);
-    return await this.getNamingMethodOrThrow(domain).record(domain, 'ipfs.redirect_domain.value');
+    return await this.getNamingMethodOrThrow(domain).record(
+      domain,
+      'ipfs.redirect_domain.value',
+    );
   }
 
   /**
@@ -254,7 +260,10 @@ export default class Resolution {
    */
   async email(domain: string): Promise<string> {
     domain = this.prepareDomain(domain);
-    return await this.getNamingMethodOrThrow(domain).record(domain, 'whois.email.value');
+    return await this.getNamingMethodOrThrow(domain).record(
+      domain,
+      'whois.email.value',
+    );
   }
 
   /**

--- a/src/UdApi.test.ts
+++ b/src/UdApi.test.ts
@@ -76,6 +76,19 @@ describe('Unstoppable API', () => {
         type: 'ZNS',
         ttl: 0,
       },
+      records: {
+        'ipfs.html.value': 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK',
+        'crypto.BCH.address': 'qrq4sk49ayvepqz7j7ep8x4km2qp8lauvcnzhveyu6',
+        'crypto.BTC.address': '1EVt92qQnaLDcmVFtHivRJaunG2mf2C3mB',
+        'crypto.ETH.address': '0x45b31e01AA6f42F0549aD482BE81635ED3149abb',
+        'crypto.LTC.address': 'LetmswTW3b7dgJ46mXuiXMUY17XbK29UmL',
+        'crypto.XMR.address':
+          '447d7TVFkoQ57k3jm3wGKoEAkfEym59mK96Xw5yWamDNFGaLKW5wL2qK5RMTDKGSvYfQYVN7dLSrLdkwtKH3hwbSCQCu26d',
+        'crypto.ZEC.address': 't1h7ttmQvWCSH1wfrcmvT4mZJfGw2DgCSqV',
+        'crypto.ZIL.address': 'zil1yu5u4hegy9v3xgluweg4en54zm8f8auwxu0xxj',
+        'crypto.DASH.address': 'XnixreEBqFuSLnDSLNbfqMH1GsZk7cgW4j',
+        'ipfs.redirect_domain.value': 'www.unstoppabledomains.com',
+      },
     });
     const ipfsHash = await resolution.ipfsHash('brad.zil');
     expectSpyToBeCalled([eyes]);
@@ -98,6 +111,13 @@ describe('Unstoppable API', () => {
         owner: '0x4e984952e867ff132cd4b70cd3f313d68c511b76',
         type: 'ZNS',
         ttl: 0,
+      },
+      records: {
+        'ipfs.html.hash': 'QmefehFs5n8yQcGCVJnBMY3Hr6aMRHtsoniAhsM1KsHMSe',
+        'ipfs.html.value': 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHu',
+        'whois.email.value': 'matt+test@unstoppabledomains.com',
+        'whois.for_sale.value': 'true',
+        'ipfs.redirect_domain.value': 'www.unstoppabledomains.com',
       },
     });
     const email = await resolution.email('ergergergerg.zil');
@@ -128,6 +148,19 @@ describe('Unstoppable API', () => {
         owner: '0x2d418942dce1afa02d0733a2000c71b371a6ac07',
         type: 'ZNS',
         ttl: 0,
+      },
+      records: {
+        'ipfs.html.value': 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK',
+        'crypto.BCH.address': 'qrq4sk49ayvepqz7j7ep8x4km2qp8lauvcnzhveyu6',
+        'crypto.BTC.address': '1EVt92qQnaLDcmVFtHivRJaunG2mf2C3mB',
+        'crypto.ETH.address': '0x45b31e01AA6f42F0549aD482BE81635ED3149abb',
+        'crypto.LTC.address': 'LetmswTW3b7dgJ46mXuiXMUY17XbK29UmL',
+        'crypto.XMR.address':
+          '447d7TVFkoQ57k3jm3wGKoEAkfEym59mK96Xw5yWamDNFGaLKW5wL2qK5RMTDKGSvYfQYVN7dLSrLdkwtKH3hwbSCQCu26d',
+        'crypto.ZEC.address': 't1h7ttmQvWCSH1wfrcmvT4mZJfGw2DgCSqV',
+        'crypto.ZIL.address': 'zil1yu5u4hegy9v3xgluweg4en54zm8f8auwxu0xxj',
+        'crypto.DASH.address': 'XnixreEBqFuSLnDSLNbfqMH1GsZk7cgW4j',
+        'ipfs.redirect_domain.value': 'www.unstoppabledomains.com',
       },
     });
     const httpUrl = await resolution.httpUrl('brad.zil');

--- a/src/UdApi.ts
+++ b/src/UdApi.ts
@@ -96,10 +96,8 @@ export default class Udapi extends NamingService {
   }
 
   async record(domain: string, key: string): Promise<string> {
-    const resolution = await this.resolve(domain);
-    const keyParts = key.split('.');
-    const value = resolution[keyParts[0]][keyParts[1]];
-    return this.ensureRecordPresence(domain, keyParts[1], value);
+    const value = (await this.allRecords(domain))[key];
+    return this.ensureRecordPresence(domain, key, value);
   }
 
   async allRecords(domain: string): Promise<Record<string, string>> {

--- a/src/UdApi.ts
+++ b/src/UdApi.ts
@@ -97,14 +97,14 @@ export default class Udapi extends NamingService {
 
   async record(domain: string, key: string): Promise<string> {
     const resolution = await this.resolve(domain);
-    
+
     // ipfs.redirect_domain.value
     // ipfs.html.value
     // gundb.username.value
     // gundb.public_key.value
     // whois.email.value
     // crypto.BTC.address
-    
+
     const keyParts = key.split('.');
     const value = resolution[keyParts[0]][keyParts[1]];
     return this.ensureRecordPresence(domain, keyParts[1], value);

--- a/src/UdApi.ts
+++ b/src/UdApi.ts
@@ -95,6 +95,21 @@ export default class Udapi extends NamingService {
     return this.ensureRecordPresence(domain, 'httpUrl', value);
   }
 
+  async record(domain: string, key: string): Promise<string> {
+    const resolution = await this.resolve(domain);
+    
+    // ipfs.redirect_domain.value
+    // ipfs.html.value
+    // gundb.username.value
+    // gundb.public_key.value
+    // whois.email.value
+    // crypto.BTC.address
+    
+    const keyParts = key.split('.');
+    const value = resolution[keyParts[0]][keyParts[1]];
+    return this.ensureRecordPresence(domain, keyParts[1], value);
+  }
+
   async allRecords(domain: string): Promise<Record<string, string>> {
     return (await this.resolve(domain)).records || {};
   }
@@ -143,9 +158,5 @@ export default class Udapi extends NamingService {
       });
     }
     return method;
-  }
-
-  async record(domain: string, key: string): Promise<string> {
-    return await this.findMethodOrThrow(domain).record(domain, key);
   }
 }

--- a/src/UdApi.ts
+++ b/src/UdApi.ts
@@ -97,14 +97,6 @@ export default class Udapi extends NamingService {
 
   async record(domain: string, key: string): Promise<string> {
     const resolution = await this.resolve(domain);
-
-    // ipfs.redirect_domain.value
-    // ipfs.html.value
-    // gundb.username.value
-    // gundb.public_key.value
-    // whois.email.value
-    // crypto.BTC.address
-
     const keyParts = key.split('.');
     const value = resolution[keyParts[0]][keyParts[1]];
     return this.ensureRecordPresence(domain, keyParts[1], value);

--- a/src/Zns.ts
+++ b/src/Zns.ts
@@ -90,26 +90,6 @@ export default class Zns extends NamingService {
     return data ? data.meta.owner : null;
   }
 
-  async ipfsHash(domain: string): Promise<string> {
-    return await this.getRecordOrThrow(domain, 'ipfs.html.value');
-  }
-
-  async httpUrl(domain: string): Promise<string> {
-    return await this.getRecordOrThrow(domain, 'ipfs.redirect_domain.value');
-  }
-
-  async email(domain: string): Promise<string> {
-    return await this.getRecordOrThrow(domain, 'whois.email.value');
-  }
-
-  async chatId(domain: string): Promise<string> {
-    return await this.getRecordOrThrow(domain, 'gundb.username.value');
-  }
-
-  async chatpk(domain: string): Promise<string> {
-    return await this.getRecordOrThrow(domain, 'gundb.public_key.value');
-  }
-
   async record(domain: string, field: string) {
     return await this.getRecordOrThrow(domain, field);
   }


### PR DESCRIPTION
We don't really need these functions on NamingService level. We can always use record method. 

For Ens I made the mapping between our "hard-coded" query codes and ens alternative.

NamingService#record method is not recommended to use to resolve crypto addresses or ipfs hash values since ens stores them completely differently, but any other text record can be resolved.