### PR TITLE
start supporting new keys from docs

### DIFF
--- a/src/Cns.test.ts
+++ b/src/Cns.test.ts
@@ -163,6 +163,20 @@ describe('CNS', () => {
         expect(hash).toBe('new record Ipfs hash');
       });
 
+      it('should prioritize browser record key over ipfs.redirect_url one', async () => {
+        pendingInLive();
+        const spies = mockAsyncMethods(reader, {
+          records: {
+            resolver: '0xA1cAc442Be6673C49f8E74FFC7c4fD746f3cBD0D',
+            values: ['oldRecord redirect url', 'new record redirect url']
+          }
+        });
+        const redirectUrl = await resolution.httpUrl(CryptoDomainWithIpfsRecords);
+        expectSpyToBeCalled(spies);
+        expect(redirectUrl).toBe('new record redirect url');
+
+      });
+
       it('should resolve with ipfs stored on cns', async () => {
         const spies = mockAsyncMethods(reader, {
           records: {

--- a/src/Cns.ts
+++ b/src/Cns.ts
@@ -155,7 +155,9 @@ export default class Cns extends EthereumNamingService {
     const data = await reader.records(tokenId, keys);
     await this.verify(domain, data);
 
-    if (!data.values) return {};
+    if (!data.values) {
+      return {};
+    }
     const records: Record<string, string> = {};
     keys.forEach((key, index) => records[key] = data.values![index])
     return records;

--- a/src/Cns.ts
+++ b/src/Cns.ts
@@ -15,7 +15,6 @@ import {
   ResolutionResponse,
 } from './publicTypes';
 import { isValidTwitterSignature } from './utils/TwitterSignatureValidator';
-import { read } from 'fs';
 
 const ReaderMap: ReaderMap = {
   1: '0x7ea9ee21077f84339eda9c80048ec6db678642b1',

--- a/src/NamingService.ts
+++ b/src/NamingService.ts
@@ -1,4 +1,3 @@
-import BN from 'bn.js';
 import {
   ResolutionMethod,
   Provider,
@@ -23,7 +22,7 @@ export default abstract class NamingService extends BaseConnection {
   abstract isSupportedDomain(domain: string): boolean;
   abstract isSupportedNetwork(): boolean;
   abstract owner(domain: string): Promise<string | null>;
-  abstract record(domain: string, key: string): Promise<string>;
+  abstract records(domain: string, key: string[]): Promise<Record<string, string>>;
   abstract resolve(domain: string): Promise<ResolutionResponse | null>;
   abstract resolver(domain: string): Promise<string>;
   abstract twitter(domain: string): Promise<string>;
@@ -74,7 +73,6 @@ export default abstract class NamingService extends BaseConnection {
         domain,
       });
     }
-    
   }
 
   protected async ignoreResolutionErrors<T>(
@@ -89,27 +87,11 @@ export default abstract class NamingService extends BaseConnection {
       } else {
         throw error;
       }
-      
     }
   }
 
   protected isResolutionError(error: any, code?: ResolutionErrorCode): boolean {
     return error instanceof ResolutionError && (!code || error.code === code);
-  }
-
-  protected ensureRecordPresence(
-    domain: string,
-    key: string,
-    value: string | undefined | null,
-  ): string {
-    if (value) {
-      return value;
-    }
-    
-    throw new ResolutionError(ResolutionErrorCode.RecordNotFound, {
-      recordName: key,
-      domain: domain,
-    });
   }
 
   protected ensureConfigured(source: SourceDefinition): void {
@@ -124,6 +106,5 @@ export default abstract class NamingService extends BaseConnection {
         method: this.name,
       });
     }
-    
   }
 }

--- a/src/Resolution.test.ts
+++ b/src/Resolution.test.ts
@@ -35,143 +35,147 @@ beforeEach(() => {
 });
 
 describe('Resolution', () => {
-  it('should get a valid resolution instance', async () => {
-    const resolution = Resolution.infura('api-key');
-    expect(resolution.ens).toBeDefined();
-    expect(resolution.ens!.url).toBe(`https://mainnet.infura.com/v3/api-key`);
+  describe('.Basics', () => { 
+    it('should get a valid resolution instance', async () => {
+      const resolution = Resolution.infura('api-key');
+      expect(resolution.ens).toBeDefined();
+      expect(resolution.ens!.url).toBe(`https://mainnet.infura.com/v3/api-key`);
 
-    expect(resolution.cns).toBeDefined();
-    expect(resolution.cns!.url).toBe(`https://mainnet.infura.com/v3/api-key`);
-  });
-
-  it('checks Resolution#addr error #1', async () => {
-    const resolution = new Resolution();
-    await expectResolutionErrorCode(
-      resolution.addr('sdncdoncvdinvcsdncs.zil', 'ZIL'),
-      ResolutionErrorCode.UnregisteredDomain,
-    );
-  });
-
-  it('resolves non-existing domain zone with throw', async () => {
-    const resolution = new Resolution({ blockchain: true });
-    await expectResolutionErrorCode(
-      resolution.addr('bogdangusiev.qq', 'ZIL'),
-      ResolutionErrorCode.UnsupportedDomain,
-    );
-  });
-
-  it('provides empty response constant', async () => {
-    const response = UnclaimedDomainResponse;
-    expect(response.addresses).toEqual({});
-    expect(response.meta.owner).toEqual(null);
-  });
-
-  it('checks the isSupportedDomainInNetwork', async () => {
-    const resolution = new Resolution();
-    const result = resolution.isSupportedDomainInNetwork('brad.zil');
-    expect(result).toBe(true);
-  });
-
-  it('checks namehash for unsupported domain', async () => {
-    const resolution = new Resolution();
-    await expectResolutionErrorCode(
-      () => resolution.namehash('something.hello.com'),
-      ResolutionErrorCode.UnsupportedDomain,
-    );
-  });
-
-  it('checks return of IPFS hash for brad.zil', async () => {
-    const resolution = new Resolution();
-    const spies = mockAsyncMethods(resolution.zns, {
-      allRecords: {
-        'crypto.BCH.address': 'qrq4sk49ayvepqz7j7ep8x4km2qp8lauvcnzhveyu6',
-        'crypto.BTC.address': '1EVt92qQnaLDcmVFtHivRJaunG2mf2C3mB',
-        'crypto.DASH.address': 'XnixreEBqFuSLnDSLNbfqMH1GsZk7cgW4j',
-        'crypto.ETH.address': '0x45b31e01AA6f42F0549aD482BE81635ED3149abb',
-        'crypto.LTC.address': 'LetmswTW3b7dgJ46mXuiXMUY17XbK29UmL',
-        'crypto.XMR.address':
-          '447d7TVFkoQ57k3jm3wGKoEAkfEym59mK96Xw5yWamDNFGaLKW5wL2qK5RMTDKGSvYfQYVN7dLSrLdkwtKH3hwbSCQCu26d',
-        'crypto.ZEC.address': 't1h7ttmQvWCSH1wfrcmvT4mZJfGw2DgCSqV',
-        'crypto.ZIL.address': 'zil1yu5u4hegy9v3xgluweg4en54zm8f8auwxu0xxj',
-        'ipfs.html.value': 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK',
-        'ipfs.redirect_domain.value': 'www.unstoppabledomains.com',
-      },
+      expect(resolution.cns).toBeDefined();
+      expect(resolution.cns!.url).toBe(`https://mainnet.infura.com/v3/api-key`);
     });
-    const hash = await resolution.ipfsHash('brad.zil');
-    expectSpyToBeCalled(spies);
-    expect(hash).toBe('QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK');
+
+    it('checks Resolution#addr error #1', async () => {
+      const resolution = new Resolution();
+      await expectResolutionErrorCode(
+        resolution.addr('sdncdoncvdinvcsdncs.zil', 'ZIL'),
+        ResolutionErrorCode.UnregisteredDomain,
+      );
+    });
+
+    it('resolves non-existing domain zone with throw', async () => {
+      const resolution = new Resolution({ blockchain: true });
+      await expectResolutionErrorCode(
+        resolution.addr('bogdangusiev.qq', 'ZIL'),
+        ResolutionErrorCode.UnsupportedDomain,
+      );
+    });
+
+    it('provides empty response constant', async () => {
+      const response = UnclaimedDomainResponse;
+      expect(response.addresses).toEqual({});
+      expect(response.meta.owner).toEqual(null);
+    });
+
+    it('checks the isSupportedDomainInNetwork', async () => {
+      const resolution = new Resolution();
+      const result = resolution.isSupportedDomainInNetwork('brad.zil');
+      expect(result).toBe(true);
+    });
+
+    it('checks namehash for unsupported domain', async () => {
+      const resolution = new Resolution();
+      await expectResolutionErrorCode(
+        () => resolution.namehash('something.hello.com'),
+        ResolutionErrorCode.UnsupportedDomain,
+      );
+    });
   });
 
-  it('checks return of email for ergergergerg.zil', async () => {
-    const resolution = new Resolution();
-    const email = await resolution.email('ergergergerg.zil');
-    expect(email).toBe('matt+test@unstoppabledomains.com');
-  });
-
-  it('checks error for email on brad.zil', async () => {
-    const resolution = new Resolution();
-    await expectResolutionErrorCode(
-      resolution.email('brad.zil'),
-      ResolutionErrorCode.RecordNotFound,
-    );
-  });
-
-  it('should be invalid domain', async () => {
-    const resolution = new Resolution();
-    await expectResolutionErrorCode(
-      () => resolution.namehash('-hello.eth'),
-      ResolutionErrorCode.UnsupportedDomain,
-    );
-  });
-
-  it('should be invalid domain 2', async () => {
-    const resolution = new Resolution();
-    await expectResolutionErrorCode(
-      () => resolution.namehash('whatever-.eth'),
-      ResolutionErrorCode.UnsupportedDomain,
-    );
-  });
-
-  it('should be invalid domain 3', async () => {
-    const cnsInvalidDomain = 'hello..crypto';
-    const ensInvalidDomain = 'hello..eth';
-    const znsInvalidDomain = 'hello..zil';
-    const resolution = new Resolution();
-    await expectResolutionErrorCode(
-      () => resolution.namehash(cnsInvalidDomain),
-      ResolutionErrorCode.UnsupportedDomain,
-    );
-    await expectResolutionErrorCode(
-      () => resolution.namehash(ensInvalidDomain),
-      ResolutionErrorCode.UnsupportedDomain,
-    );
-    await expectResolutionErrorCode(
-      () => resolution.namehash(znsInvalidDomain),
-      ResolutionErrorCode.UnsupportedDomain,
-    );
-  });
-
-  it(`domains "brad.crypto" and "Brad.crypto" should return the same results`, async () => {
-    const resolution = new Resolution({
-      blockchain: {
-        cns: {
-          url: protocolLink(),
-          registry: '0xD1E5b0FF1287aA9f9A268759062E4Ab08b9Dacbe',
+  describe('.Records', () => {
+    it('checks return of IPFS hash for brad.zil', async () => {
+      const resolution = new Resolution();
+      const spies = mockAsyncMethods(resolution.zns, {
+        allRecords: {
+          'crypto.BCH.address': 'qrq4sk49ayvepqz7j7ep8x4km2qp8lauvcnzhveyu6',
+          'crypto.BTC.address': '1EVt92qQnaLDcmVFtHivRJaunG2mf2C3mB',
+          'crypto.DASH.address': 'XnixreEBqFuSLnDSLNbfqMH1GsZk7cgW4j',
+          'crypto.ETH.address': '0x45b31e01AA6f42F0549aD482BE81635ED3149abb',
+          'crypto.LTC.address': 'LetmswTW3b7dgJ46mXuiXMUY17XbK29UmL',
+          'crypto.XMR.address':
+            '447d7TVFkoQ57k3jm3wGKoEAkfEym59mK96Xw5yWamDNFGaLKW5wL2qK5RMTDKGSvYfQYVN7dLSrLdkwtKH3hwbSCQCu26d',
+          'crypto.ZEC.address': 't1h7ttmQvWCSH1wfrcmvT4mZJfGw2DgCSqV',
+          'crypto.ZIL.address': 'zil1yu5u4hegy9v3xgluweg4en54zm8f8auwxu0xxj',
+          'ipfs.html.value': 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK',
+          'ipfs.redirect_domain.value': 'www.unstoppabledomains.com',
         },
-      },
+      });
+      const hash = await resolution.ipfsHash('brad.zil');
+      expectSpyToBeCalled(spies);
+      expect(hash).toBe('QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK');
     });
-    const reader = await resolution.cns!.getReader();
-    const eyes = mockAsyncMethods(reader, {
-      record: {
-        resolver: '0xBD5F5ec7ed5f19b53726344540296C02584A5237',
-        values: ['0x45b31e01AA6f42F0549aD482BE81635ED3149abb'],
-      },
+
+    it('checks return of email for ergergergerg.zil', async () => {
+      const resolution = new Resolution();
+      const email = await resolution.email('ergergergerg.zil');
+      expect(email).toBe('matt+test@unstoppabledomains.com');
     });
-    const capital = await resolution.addr('Brad.crypto', 'eth');
-    expectSpyToBeCalled(eyes);
-    const lower = await resolution.addr('brad.crypto', 'eth');
-    expectSpyToBeCalled(eyes);
-    expect(capital).toStrictEqual(lower);
+
+    it('checks error for email on brad.zil', async () => {
+      const resolution = new Resolution();
+      await expectResolutionErrorCode(
+        resolution.email('brad.zil'),
+        ResolutionErrorCode.RecordNotFound,
+      );
+    });
+
+    it('should be invalid domain', async () => {
+      const resolution = new Resolution();
+      await expectResolutionErrorCode(
+        () => resolution.namehash('-hello.eth'),
+        ResolutionErrorCode.UnsupportedDomain,
+      );
+    });
+
+    it('should be invalid domain 2', async () => {
+      const resolution = new Resolution();
+      await expectResolutionErrorCode(
+        () => resolution.namehash('whatever-.eth'),
+        ResolutionErrorCode.UnsupportedDomain,
+      );
+    });
+
+    it('should be invalid domain 3', async () => {
+      const cnsInvalidDomain = 'hello..crypto';
+      const ensInvalidDomain = 'hello..eth';
+      const znsInvalidDomain = 'hello..zil';
+      const resolution = new Resolution();
+      await expectResolutionErrorCode(
+        () => resolution.namehash(cnsInvalidDomain),
+        ResolutionErrorCode.UnsupportedDomain,
+      );
+      await expectResolutionErrorCode(
+        () => resolution.namehash(ensInvalidDomain),
+        ResolutionErrorCode.UnsupportedDomain,
+      );
+      await expectResolutionErrorCode(
+        () => resolution.namehash(znsInvalidDomain),
+        ResolutionErrorCode.UnsupportedDomain,
+      );
+    });
+
+    it(`domains "brad.crypto" and "Brad.crypto" should return the same results`, async () => {
+      const resolution = new Resolution({
+        blockchain: {
+          cns: {
+            url: protocolLink(),
+            registry: '0xD1E5b0FF1287aA9f9A268759062E4Ab08b9Dacbe',
+          },
+        },
+      });
+      const reader = await resolution.cns!.getReader();
+      const eyes = mockAsyncMethods(reader, {
+        records: {
+          resolver: '0xBD5F5ec7ed5f19b53726344540296C02584A5237',
+          values: ['0x45b31e01AA6f42F0549aD482BE81635ED3149abb'],
+        },
+      });
+      const capital = await resolution.addr('Brad.crypto', 'eth');
+      expectSpyToBeCalled(eyes);
+      const lower = await resolution.addr('brad.crypto', 'eth');
+      expectSpyToBeCalled(eyes);
+      expect(capital).toStrictEqual(lower);
+    });
   });
 
   it('should resolve gundb chat id', async () => {
@@ -185,7 +189,7 @@ describe('Resolution', () => {
     });
     const reader = await resolution.cns!.getReader();
     const eyes = mockAsyncMethods(reader, {
-      record: {
+      records: {
         resolver: '0x878bC2f3f717766ab69C0A5f9A6144931E61AEd3',
         values: [
           '0x47992daf742acc24082842752fdc9c875c87c56864fee59d8b779a91933b159e48961566eec6bd6ce3ea2441c6cb4f112d0eb8e8855cc9cf7647f0d9c82f00831c',
@@ -278,8 +282,8 @@ describe('Resolution', () => {
     });
   });
 
-  describe('isValidHash', () => {
-    it('works', async () => {
+  describe('.Hashing', () => {
+    it('isValidHash', async () => {
       const resolution = new Resolution();
       const domain = 'hello.world.zil';
       const hash = resolution.namehash(domain);
@@ -287,9 +291,7 @@ describe('Resolution', () => {
       expect(resolution.isValidHash(domain, hash)).toEqual(true);
       expect(resolution.isValidHash(domain, invalidHash)).toEqual(false);
     });
-  });
 
-  describe('.Hashing', () => {
     describe('.childhash', () => {
       it('checks childhash', () => {
         const resolution = new Resolution();

--- a/src/Resolution.test.ts
+++ b/src/Resolution.test.ts
@@ -105,44 +105,44 @@ describe('Resolution', () => {
       expect(hash).toBe('QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK');
     });
 
-  it('checks return of email for ergergergerg.zil', async () => {
-    const resolution = new Resolution();
-    const spies = mockAsyncMethods(resolution.zns, {
-      allRecords: {
-        'ipfs.html.hash': 'QmefehFs5n8yQcGCVJnBMY3Hr6aMRHtsoniAhsM1KsHMSe',
-        'ipfs.html.value': 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHu',
-        'ipfs.redirect_domain.value': 'www.unstoppabledomains.com',
-        'whois.email.value': 'matt+test@unstoppabledomains.com',
-        'whois.for_sale.value': 'true'
-      }
+    it('checks return of email for ergergergerg.zil', async () => {
+      const resolution = new Resolution();
+      const spies = mockAsyncMethods(resolution.zns, {
+        allRecords: {
+          'ipfs.html.hash': 'QmefehFs5n8yQcGCVJnBMY3Hr6aMRHtsoniAhsM1KsHMSe',
+          'ipfs.html.value': 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHu',
+          'ipfs.redirect_domain.value': 'www.unstoppabledomains.com',
+          'whois.email.value': 'matt+test@unstoppabledomains.com',
+          'whois.for_sale.value': 'true'
+        }
+      });
+      const email = await resolution.email('ergergergerg.zil');
+      expectSpyToBeCalled(spies);
+      expect(email).toBe('matt+test@unstoppabledomains.com');
     });
-    const email = await resolution.email('ergergergerg.zil');
-    expectSpyToBeCalled(spies);
-    expect(email).toBe('matt+test@unstoppabledomains.com');
-  });
 
-  it('checks error for email on brad.zil', async () => {
-    const resolution = new Resolution();
-    const spies = mockAsyncMethods(resolution.zns, {
-      allRecords: {
-        'crypto.BCH.address': 'qrq4sk49ayvepqz7j7ep8x4km2qp8lauvcnzhveyu6',
-        'crypto.BTC.address': '1EVt92qQnaLDcmVFtHivRJaunG2mf2C3mB',
-        'crypto.DASH.address': 'XnixreEBqFuSLnDSLNbfqMH1GsZk7cgW4j',
-        'crypto.ETH.address': '0x45b31e01AA6f42F0549aD482BE81635ED3149abb',
-        'crypto.LTC.address': 'LetmswTW3b7dgJ46mXuiXMUY17XbK29UmL',
-        'crypto.XMR.address': '447d7TVFkoQ57k3jm3wGKoEAkfEym59mK96Xw5yWamDNFGaLKW5wL2qK5RMTDKGSvYfQYVN7dLSrLdkwtKH3hwbSCQCu26d',
-        'crypto.ZEC.address': 't1h7ttmQvWCSH1wfrcmvT4mZJfGw2DgCSqV',
-        'crypto.ZIL.address': 'zil1yu5u4hegy9v3xgluweg4en54zm8f8auwxu0xxj',
-        'ipfs.html.value': 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK',
-        'ipfs.redirect_domain.value': 'www.unstoppabledomains.com'
-      }
+    it('checks error for email on brad.zil', async () => {
+      const resolution = new Resolution();
+      const spies = mockAsyncMethods(resolution.zns, {
+        allRecords: {
+          'crypto.BCH.address': 'qrq4sk49ayvepqz7j7ep8x4km2qp8lauvcnzhveyu6',
+          'crypto.BTC.address': '1EVt92qQnaLDcmVFtHivRJaunG2mf2C3mB',
+          'crypto.DASH.address': 'XnixreEBqFuSLnDSLNbfqMH1GsZk7cgW4j',
+          'crypto.ETH.address': '0x45b31e01AA6f42F0549aD482BE81635ED3149abb',
+          'crypto.LTC.address': 'LetmswTW3b7dgJ46mXuiXMUY17XbK29UmL',
+          'crypto.XMR.address': '447d7TVFkoQ57k3jm3wGKoEAkfEym59mK96Xw5yWamDNFGaLKW5wL2qK5RMTDKGSvYfQYVN7dLSrLdkwtKH3hwbSCQCu26d',
+          'crypto.ZEC.address': 't1h7ttmQvWCSH1wfrcmvT4mZJfGw2DgCSqV',
+          'crypto.ZIL.address': 'zil1yu5u4hegy9v3xgluweg4en54zm8f8auwxu0xxj',
+          'ipfs.html.value': 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK',
+          'ipfs.redirect_domain.value': 'www.unstoppabledomains.com'
+        }
+      });
+      await expectResolutionErrorCode(
+        resolution.email('brad.zil'),
+        ResolutionErrorCode.RecordNotFound,
+      );
+      expectSpyToBeCalled(spies);
     });
-    await expectResolutionErrorCode(
-      resolution.email('brad.zil'),
-      ResolutionErrorCode.RecordNotFound,
-    );
-    expectSpyToBeCalled(spies);
-  });
 
     it('should be invalid domain', async () => {
       const resolution = new Resolution();

--- a/src/Resolution.ts
+++ b/src/Resolution.ts
@@ -261,7 +261,7 @@ export default class Resolution {
    */
   async ipfsHash(domain: string): Promise<string> {
     const [oldRecord, newRecord] = ['ipfs.html.value', 'dweb.ipfs.hash'];
-    const records = await this.records(domain, ['ipfs.html.value', 'dweb.ipfs.hash']);
+    const records = await this.records(domain, [oldRecord, newRecord]);
     if (records[newRecord]) {return records[newRecord];}
     return ensureRecordPresence(domain, 'ipfs hash', records[oldRecord]);
   }
@@ -272,7 +272,7 @@ export default class Resolution {
    */
   async httpUrl(domain: string): Promise<string> {
     const [oldRecord, newRecord] = ['ipfs.redirect_domain.value', 'browser.redirect_url'];
-    const records = await this.records(domain, ['ipfs.redirect_domain.value', 'browser.redirect_url']);
+    const records = await this.records(domain, [oldRecord, newRecord]);
     if (records[newRecord]) {return records[newRecord];}
     return ensureRecordPresence(domain, 'ipfs redirect_url', records[oldRecord]);
   }

--- a/src/Resolution.ts
+++ b/src/Resolution.ts
@@ -262,7 +262,9 @@ export default class Resolution {
   async ipfsHash(domain: string): Promise<string> {
     const [oldRecord, newRecord] = ['ipfs.html.value', 'dweb.ipfs.hash'];
     const records = await this.records(domain, [oldRecord, newRecord]);
-    if (records[newRecord]) {return records[newRecord];}
+    if (records[newRecord]) {
+      return records[newRecord];
+    }
     return ensureRecordPresence(domain, 'ipfs hash', records[oldRecord]);
   }
 
@@ -273,7 +275,9 @@ export default class Resolution {
   async httpUrl(domain: string): Promise<string> {
     const [oldRecord, newRecord] = ['ipfs.redirect_domain.value', 'browser.redirect_url'];
     const records = await this.records(domain, [oldRecord, newRecord]);
-    if (records[newRecord]) {return records[newRecord];}
+    if (records[newRecord]) {
+      return records[newRecord];
+    }
     return ensureRecordPresence(domain, 'ipfs redirect_url', records[oldRecord]);
   }
 

--- a/src/Zns.ts
+++ b/src/Zns.ts
@@ -4,7 +4,7 @@ import {
   toBech32Address,
   toChecksumAddress,
 } from './zns/utils';
-import { invert, set } from './utils';
+import { ensureRecordPresence, invert, set } from './utils';
 import { Dictionary, ZnsResolution, isNullAddress, nodeHash } from './types';
 import {
   NamingServiceName,
@@ -73,8 +73,11 @@ export default class Zns extends NamingService {
     return data ? data.meta.owner : null;
   }
 
-  async record(domain: string, field: string) {
-    return await this.getRecordOrThrow(domain, field);
+  async records(domain: string, keys: string[]): Promise<Record<string, string>> {
+    const allRecords = await this.allRecords(domain);
+    const neededRecords: Record<string, string> = {};
+    keys.forEach(key => neededRecords[key] = allRecords[key]);
+    return neededRecords;
   }
 
   async allRecords(domain: string): Promise<Record<string, string>> {
@@ -162,7 +165,7 @@ export default class Zns extends NamingService {
     field: string,
   ): Promise<string> {
     const records = await this.allRecords(domain);
-    return this.ensureRecordPresence(domain, field, records[field]);
+    return ensureRecordPresence(domain, field, records[field]);
   }
 
   private async getRecordsAddresses(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,5 @@
+import { ResolutionError, ResolutionErrorCode } from "../errors/resolutionError";
+
 /**
  * Parses object in format { "key.key2.key3" : value } into { key: { key2: {key3: value } } }
  * @param object object to parse
@@ -54,4 +56,19 @@ export function hexToBytes(hexString: string): number[] {
   }
   
   return bytes;
+}
+
+export function ensureRecordPresence(
+  domain: string,
+  key: string,
+  value: string | undefined | null,
+): string {
+  if (value) {
+    return value;
+  }
+  
+  throw new ResolutionError(ResolutionErrorCode.RecordNotFound, {
+    recordName: key,
+    domain: domain,
+  });
 }


### PR DESCRIPTION
The main purpose of this PR is to start supporting new keys from our [docs](https://docs.unstoppabledomains.com/domain-registry-essentials/records-reference).

We are checking for the new record and the old record. If a new record exists we return it. Otherwise, we check if old record is present. We throw a RecordNotFound in case if it is not present. 

Additionally: 
* I removed `NamingService#record` in the favor of `NamingService#records`
There are several reasons for this change:
* * It is better to have a single option from the top-level class than 2 (record and records). We can always use records with just a single record key if needed.
* * Made sure that instead of returning string[] I return Record<string, string> as this seems to be the direction this library goes
* * This should make it easier to work in future supporting DNS keys (out of the scope of this PR). I will need to get more than 1 record per DNS record. (each record can have their own TTL under dns.RECORD.ttl, if it doesn't I will need to get the default ttl under dns.ttl). Asking a smart contract to give me records for all ttls allows me to save async network calls # and make it more efficient. 
* Because of the change above I moved the `ensureRecordPresence` function from NamingService to utils and exported it from the file. This allows Resolution to check if the record is present or throw the RecordNotFound if not when using `NamingService#records`

Tests:
I checked the tests via LIVE mode and after ensured they passed, I fixed the mocking calls. Before we were calling ICnsReader#record now we call ICnsReader#records 
