### PR TITLE
rename error

### DIFF
--- a/src/DnsUtils.test.ts
+++ b/src/DnsUtils.test.ts
@@ -110,7 +110,7 @@ describe('DnsUtils', () => {
         { TTL: 90, data: '10.0.0.20', type: 'A' as DnsRecordType },
         { TTL: 900, data: '10.0.0.20', type: 'A' as DnsRecordType }
       ];
-      expectDnsRecordErrorCode(() => dnsUtils.toCrypto(classicalRecords), DnsRecordsErrorCode.TtlInconsistent);
+      expectDnsRecordErrorCode(() => dnsUtils.toCrypto(classicalRecords), DnsRecordsErrorCode.InconsistentTtl);
     });
 
   });

--- a/src/DnsUtils.ts
+++ b/src/DnsUtils.ts
@@ -27,7 +27,7 @@ export default class DnsUtils {
       }
 
       if (!!ttlInRecord && ttlInRecord !== TTL) {
-        throw new DnsRecordsError(DnsRecordsErrorCode.TtlInconsistent, {recordType: type});
+        throw new DnsRecordsError(DnsRecordsErrorCode.InconsistentTtl, {recordType: type});
       }
     }
     return cryptoRecords;

--- a/src/errors/dnsRecordsError.ts
+++ b/src/errors/dnsRecordsError.ts
@@ -6,7 +6,7 @@ type DnsRecordsErrorOptions = {
 };
 
 export enum DnsRecordsErrorCode {
-  TtlInconsistent = "TtlInconsistent",
+  InconsistentTtl = "InconsistentTtl",
   DnsRecordCorrupted = "DnsRecordCorrupted"
 }
 
@@ -15,7 +15,7 @@ export enum DnsRecordsErrorCode {
  * Internal Mapping object from DnsRecordsErrorCode to a DnsRecordsErrorHandler
  */
 const HandlersByCode = {
-  [DnsRecordsErrorCode.TtlInconsistent]: (params: DnsRecordsErrorOptions) => `ttl for record ${params.recordType} is different for other records of the same type`,
+  [DnsRecordsErrorCode.InconsistentTtl]: (params: DnsRecordsErrorOptions) => `ttl for record ${params.recordType} is different for other records of the same type`,
   [DnsRecordsErrorCode.DnsRecordCorrupted]: (params: DnsRecordsErrorOptions) => `dns record ${params.recordType} is invalid json-string`
 };
 


### PR DESCRIPTION
Before the next release, we need to make sure the error is the right name convention as we won't be able to change it. 

So the question is TtlInconsistent or InconsistentTtl ?

Right now in the master, it is using TtlInconsistent, 
@mvlabat, as I understood, wants to make sure it will be InconsistentTtl. 
@bogdan  what do you think? 