### PR TITLE
removed elliptic dependacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `Resolution#dns` method to query dns records from blockchain #99
 * Add DnsUtils as a helper class to convert from CryptoRecord type to DnsRecord and vice-versa #99
 * Plug-in network config from dot-crypto library #101
+* Removed elliptic from dependacy list. (when needed user should install it separately)
 
 ## 1.8.3
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   "devDependencies": {
     "@ethersproject/providers": "^5.0.2",
     "@types/bn.js": "^4.11.6",
-    "@types/elliptic": "^6.4.12",
     "@types/jest": "24.0.23",
     "@types/lodash": "^4.14.158",
     "@types/node": "11.15.3",
@@ -102,7 +101,6 @@
     "bn.js": "^4.4.0",
     "commander": "^4.1.1",
     "content-hash": "^2.5.2",
-    "elliptic": "^6.5.3",
     "ethereum-ens-network-map": "^1.0.2",
     "hash.js": "^1.1.7",
     "js-sha3": "^0.8.0",

--- a/src/errors/configurationError.ts
+++ b/src/errors/configurationError.ts
@@ -6,7 +6,7 @@ type ConfigurationErrorHandler = (error: ConfigurationErrorOptions) => string;
 /** Explains Resolution Error options */
 type ConfigurationErrorOptions = {
   method?: ResolutionMethod;
-  dependacy?: string;
+  dependency?: string;
   version?: string;
 };
 
@@ -15,7 +15,7 @@ export enum ConfigurationErrorCode {
   UnspecifiedNetwork = 'UnspecifiedNetwork',
   UnspecifiedUrl = 'UnspecifiedUrl',
   MissingProviderConfigurations = 'MissingProviderConfigurations',
-  DependacyMissing = "DependacyMissing"
+  DependencyMissing = "DependencyMissing"
 }
 
 /**
@@ -33,8 +33,8 @@ const HandlersByCode = {
   }) => `Unspecified url in Resolution ${params.method} configuration`,
   [ConfigurationErrorCode.MissingProviderConfigurations]: (params: {}) =>
     `Couldn't find any configurations\n\tUse -C to configurate the library`,
-  [ConfigurationErrorCode.DependacyMissing]: (params: {dependacy: string, version: string}) => 
-    `Missing dependacy for this functionality. Please install ${params.dependacy} @ ${params.version} via npm or yarn`
+  [ConfigurationErrorCode.DependencyMissing]: (params: {dependecy: string, version: string}) => 
+    `Missing dependency for this functionality. Please install ${params.dependecy} @ ${params.version} via npm or yarn`
 };
 
 /**

--- a/src/errors/configurationError.ts
+++ b/src/errors/configurationError.ts
@@ -6,6 +6,8 @@ type ConfigurationErrorHandler = (error: ConfigurationErrorOptions) => string;
 /** Explains Resolution Error options */
 type ConfigurationErrorOptions = {
   method?: ResolutionMethod;
+  dependacy?: string;
+  version?: string;
 };
 
 export enum ConfigurationErrorCode {
@@ -13,6 +15,7 @@ export enum ConfigurationErrorCode {
   UnspecifiedNetwork = 'UnspecifiedNetwork',
   UnspecifiedUrl = 'UnspecifiedUrl',
   MissingProviderConfigurations = 'MissingProviderConfigurations',
+  DependacyMissing = "DependacyMissing"
 }
 
 /**
@@ -30,6 +33,8 @@ const HandlersByCode = {
   }) => `Unspecified url in Resolution ${params.method} configuration`,
   [ConfigurationErrorCode.MissingProviderConfigurations]: (params: {}) =>
     `Couldn't find any configurations\n\tUse -C to configurate the library`,
+  [ConfigurationErrorCode.DependacyMissing]: (params: {dependacy: string, version: string}) => 
+    `Missing dependacy for this functionality. Please install ${params.dependacy} @ ${params.version} via npm or yarn`
 };
 
 /**
@@ -50,10 +55,9 @@ export class ConfigurationError extends Error {
   ) {
     const configurationErrorHandler: ConfigurationErrorHandler =
       HandlersByCode[code];
-    const { method } = options;
-    super(configurationErrorHandler({ method }));
+    super(configurationErrorHandler(options));
     this.code = code;
-    this.method = method;
+    this.method = options.method;
     this.name = 'ConfigurationError';
     Object.setPrototypeOf(this, ConfigurationError.prototype);
   }

--- a/src/utils/TwitterSignatureValidator.test.ts
+++ b/src/utils/TwitterSignatureValidator.test.ts
@@ -1,8 +1,8 @@
 import { isValidTwitterSignature } from './TwitterSignatureValidator';
 
 describe('TwitterSignatureValidator', () => {
-  it('should return true for valid signature', async () => {
-    const isValid = await isValidTwitterSignature({
+  it('should return true for valid signature', () => {
+    const isValid = isValidTwitterSignature({
       tokenId:
         '0xcbef5c2009359c88519191d7c0d00f3973f76f24bdb0fc8d5254de26a44e0903',
       owner: '0x6EC0DEeD30605Bcd19342f3c30201DB263291589',

--- a/src/utils/recoverSignature.ts
+++ b/src/utils/recoverSignature.ts
@@ -29,6 +29,7 @@ const toChecksum = (address: string) => {
 
 const getSecp256k1 = () => {
   try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const elliptic = require('elliptic');
     const secp256k1 = new elliptic.ec('secp256k1');
     return secp256k1;

--- a/src/utils/recoverSignature.ts
+++ b/src/utils/recoverSignature.ts
@@ -34,8 +34,8 @@ const getSecp256k1 = () => {
     const secp256k1 = new elliptic.ec('secp256k1');
     return secp256k1;
   } catch(err) {
-    throw new ConfigurationError(ConfigurationErrorCode.DependacyMissing,
-      {dependacy: "elliptic", version: "^6.5.3"}
+    throw new ConfigurationError(ConfigurationErrorCode.DependencyMissing,
+      {dependency: "elliptic", version: "^6.5.3"}
     );
   }
 }

--- a/src/utils/recoverSignature.ts
+++ b/src/utils/recoverSignature.ts
@@ -1,9 +1,7 @@
 /* eslint-disable no-undef */
 import { keccak256 as sha3 } from 'js-sha3';
-import elliptic from 'elliptic';
 import { hexToBytes } from '.';
-// eslint-disable-next-line new-cap
-const secp256k1 = new elliptic.ec('secp256k1');
+import ConfigurationError, { ConfigurationErrorCode } from '../errors/configurationError';
 
 const bytesLength = (a: string) => (a.length - 2) / 2;
 const bytesSlice = (i: number, j: number, bs: string) =>
@@ -29,6 +27,18 @@ const toChecksum = (address: string) => {
   return checksumAddress;
 };
 
+const getSecp256k1 = () => {
+  try {
+    const elliptic = require('elliptic');
+    const secp256k1 = new elliptic.ec('secp256k1');
+    return secp256k1;
+  } catch(err) {
+    throw new ConfigurationError(ConfigurationErrorCode.DependacyMissing,
+      {dependacy: "elliptic", version: "^6.5.3"}
+    );
+  }
+}
+
 export const hashMessage = (message: string): string => {
   const messageBytes = hexToBytes(Buffer.from(message, 'utf8').toString('hex'));
   const messageBuffer = Buffer.from(messageBytes);
@@ -39,6 +49,7 @@ export const hashMessage = (message: string): string => {
 };
 
 export const recover = (message: string, signature: string): string => {
+  const secp256k1 = getSecp256k1();
   const hash = hashMessage(message);
   const vals = decodeSignature(signature);
   const vrs = {


### PR DESCRIPTION
Removed elliptic dependency.

It is quite common in crypto wallets and needed only for validating twitter signature. When user use this functionality if 
```typescript
require('elliptic')
```
fails user will see a ConfigurationError asking to install the dependency via npm or yarn. 

I tried to write a unit test for this, but failed since I can't mock the node.js "require" function and it is still being installed in our node_modules. Here is the list of elliptic notices from freshly generated yarn.lock:

```shell
"@ethersproject/signing-key@^5.0.4":
  version "5.0.7"
  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.0.7.tgz#d03bfc5f565efb962bafebf8e6965e70d1c46d31"
  integrity sha512-JYndnhFPKH0daPcIjyhi+GMcw3srIHkQ40hGRe6DA0CdGrpMfgyfSYDQ2D8HL2lgR+Xm4SHfEB0qba6+sCyrvg==
  dependencies:
    "@ethersproject/bytes" "^5.0.4"
    "@ethersproject/logger" "^5.0.5"
    "@ethersproject/properties" "^5.0.3"
    elliptic "6.5.3"

browserify-sign@^4.0.0:
  version "4.2.1"
  resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.2.1.tgz#eaf4add46dd54be3bb3b36c0cf15abbeba7956c3"
  integrity sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==
  dependencies:
    bn.js "^5.1.1"
    browserify-rsa "^4.0.1"
    create-hash "^1.2.0"
    create-hmac "^1.1.7"
    elliptic "^6.5.3"
    inherits "^2.0.4"
    parse-asn1 "^5.1.5"
    readable-stream "^3.6.0"
    safe-buffer "^5.2.0"

create-ecdh@^4.0.0:
  version "4.0.4"
  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
  integrity sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==
  dependencies:
    bn.js "^4.1.0"
    elliptic "^6.5.3"

elliptic@6.5.3, elliptic@^6.4.0, elliptic@^6.5.3:
  version "6.5.3"
  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
  dependencies:
    bn.js "^4.4.0"
    brorand "^1.0.1"
    hash.js "^1.0.0"
    hmac-drbg "^1.0.0"
    inherits "^2.0.1"
    minimalistic-assert "^1.0.0"
    minimalistic-crypto-utils "^1.0.0"
```

I am not sure if I should do anything with these packages as they are not ours.

bundlephobia reports the size of the library is reduced by ~100kb 
<img width="613" alt="Screen Shot 2020-12-02 at 12 32 17 AM" src="https://user-images.githubusercontent.com/16522024/100848346-d8320580-3435-11eb-8fb4-716b790dd9e6.png">

