### PR TITLE
Fix precommit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-
-yarn fix
+yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "eslint-plugin-jest": "^24.1.0",
     "husky": "^6.0.0",
     "jest": "^27.0.4",
+    "lint-staged": "^11.0.0",
     "lodash": "^4.17.19",
     "nock": "10.0.6",
     "nodemon": "^2.0.7",
@@ -106,5 +107,9 @@
     "js-sha256": "^0.9.0",
     "js-sha3": "^0.8.0",
     "node-fetch": "^2.6.0"
+  },
+  "lint-staged": {
+    "src/**/*.ts": "eslint --fix",
+    "src/**/*.{ts,tsx,js,jsx,json,md}": "prettier --write -l"
   }
 }


### PR DESCRIPTION
This fixes the precommit hook to run prettier and eslint on staged files and stage them after.