### PR TITLE
Replaces node-fetch with cross-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "@types/jest": "24.0.23",
     "@types/lodash": "^4.14.158",
     "@types/node": "11.15.3",
-    "@types/node-fetch": "2.5.4",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",
     "@unstoppabledomains/sizecheck": "^4.0.0",
@@ -110,11 +109,11 @@
     "@ethersproject/abi": "^5.0.1",
     "bn.js": "^4.4.0",
     "commander": "^4.1.1",
+    "cross-fetch": "^3.1.4",
     "elliptic": "^6.5.4",
     "ethereum-ens-network-map": "^1.0.2",
     "js-sha256": "^0.9.0",
-    "js-sha3": "^0.8.0",
-    "node-fetch": "^2.6.0"
+    "js-sha3": "^0.8.0"
   },
   "lint-staged": {
     "src/**/*.ts": "eslint --fix",

--- a/src/UdApi.ts
+++ b/src/UdApi.ts
@@ -34,9 +34,8 @@ export default class Udapi extends NamingService {
     super();
     this.name = 'UDAPI';
     this.url = api?.url || 'https://unstoppabledomains.com/api/v1';
-    const DefaultUserAgent = Networking.isNode()
-      ? 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)'
-      : navigator.userAgent;
+    const DefaultUserAgent =
+      'cross-fetch/3.1.4 (+https://github.com/lquixada/cross-fetch)';
     const version = pckg.version;
     const CustomUserAgent = `${DefaultUserAgent} Resolution/${version}`;
     this.headers = {'X-user-agent': CustomUserAgent};

--- a/src/utils/Networking.ts
+++ b/src/utils/Networking.ts
@@ -1,28 +1,10 @@
-import nodeFetch, {Response as FetchResponse} from 'node-fetch';
+import crossFetch from 'cross-fetch';
 
 export default class Networking {
-  static isNode(): boolean {
-    if (typeof process === 'object') {
-      // eslint-disable-next-line no-undef
-      if (typeof process.versions === 'object') {
-        // eslint-disable-next-line no-undef
-        if (typeof process.versions.node !== 'undefined') {
-          return true;
-        }
-      }
-    }
-
-    return false;
-  }
-
-  static getEnv(): 'NODE' | 'BROWSER' {
-    return this.isNode() ? 'NODE' : 'BROWSER';
-  }
-
   static async fetch(
     url: string,
     options: {body?: string; headers?: Record<string, string>; method?: string},
-  ): Promise<FetchResponse | Response> {
-    return this.isNode() ? nodeFetch(url, options) : window.fetch(url, options);
+  ): Promise<Response> {
+    return crossFetch(url, options);
   }
 }


### PR DESCRIPTION
Replaces node-fetch and window.fetch with cross-fetch


It's better to rely on a fetch library to handle detecting the runtime environment. For example Ionic framework sets process.versions.node = false which wasn't handled properly. As a result it was using node-fetch which crashes the Ionic runtime.