### PR TITLE
Config fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 8.1.0
+
+- Fixed default library configuration
+- Added function for alchemy configuration `Resolution#alchemy`
+
 ## 8.0.0
 
 - Added Node.js v16 support

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/resolution",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Domain Resolution for blockchain domains",
   "main": "./build/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "ts-node": "^8.6.2",
     "typedoc": "0.18.0",
     "typescript": "^4.2.0",
-    "web3-0.20.7": "npm:web3@0.20.7",
     "web3-providers-http": "^1.3.6",
     "web3-providers-ws": "^1.3.6"
   },

--- a/src/Resolution.ts
+++ b/src/Resolution.ts
@@ -35,6 +35,7 @@ import {NamingService} from './NamingService';
 import Networking from './utils/Networking';
 import {prepareAndValidateDomain} from './utils/prepareAndValidate';
 import {fromDecStringToHex} from './utils/namehash';
+import {UnsSupportedNetwork} from './types';
 
 /**
  * Blockchain domain Resolution library - Resolution.
@@ -120,10 +121,10 @@ export default class Resolution {
       uns?: {
         locations: {
           Layer1: {
-            network: string;
+            network: UnsSupportedNetwork;
           };
           Layer2: {
-            network: string;
+            network: UnsSupportedNetwork;
           };
         };
       };
@@ -134,11 +135,64 @@ export default class Resolution {
         uns: {
           locations: {
             Layer1: {
-              url: signedLink(infura, networks?.uns?.locations.Layer1.network),
+              url: signedLink(
+                infura,
+                networks?.uns?.locations.Layer1.network || 'mainnet',
+              ),
               network: networks?.uns?.locations.Layer1.network || 'mainnet',
             },
             Layer2: {
-              url: signedLink(infura, networks?.uns?.locations.Layer2.network),
+              url: signedLink(
+                infura,
+                networks?.uns?.locations.Layer2.network || 'polygon-mainnet',
+              ),
+              network:
+                networks?.uns?.locations.Layer2.network || 'polygon-mainnet',
+            },
+          },
+        },
+      },
+    });
+  }
+
+  /**
+   * Creates a resolution with configured alchemy API keys for uns
+   * @param alchemy - alchemy API keys
+   * @param networks - an optional object that describes what network to use when connecting UNS default is mainnet
+   */
+  static alchemy(
+    alchemy: string,
+    networks?: {
+      uns?: {
+        locations: {
+          Layer1: {
+            network: UnsSupportedNetwork;
+          };
+          Layer2: {
+            network: UnsSupportedNetwork;
+          };
+        };
+      };
+    },
+  ): Resolution {
+    return new this({
+      sourceConfig: {
+        uns: {
+          locations: {
+            Layer1: {
+              url: signedLink(
+                alchemy,
+                networks?.uns?.locations.Layer1.network || 'mainnet',
+                'alchemy',
+              ),
+              network: networks?.uns?.locations.Layer1.network || 'mainnet',
+            },
+            Layer2: {
+              url: signedLink(
+                alchemy,
+                networks?.uns?.locations.Layer2.network || 'polygon-mainnet',
+                'alchemy',
+              ),
               network:
                 networks?.uns?.locations.Layer2.network || 'polygon-mainnet',
             },
@@ -260,21 +314,21 @@ export default class Resolution {
     return this.fromEthereumEip1193Provider({
       uns: networks.uns
         ? {
-            locations: {
-              Layer1: {
-                network: networks.uns.locations.Layer1.network,
-                provider: Eip1193Factories.fromWeb3Version0Provider(
-                  networks.uns.locations.Layer1.provider,
-                ),
-              },
-              Layer2: {
-                network: networks.uns.locations.Layer2.network,
-                provider: Eip1193Factories.fromWeb3Version0Provider(
-                  networks.uns.locations.Layer2.provider,
-                ),
-              },
+          locations: {
+            Layer1: {
+              network: networks.uns.locations.Layer1.network,
+              provider: Eip1193Factories.fromWeb3Version0Provider(
+                networks.uns.locations.Layer1.provider,
+              ),
             },
-          }
+            Layer2: {
+              network: networks.uns.locations.Layer2.network,
+              provider: Eip1193Factories.fromWeb3Version0Provider(
+                networks.uns.locations.Layer2.provider,
+              ),
+            },
+          },
+        }
         : undefined,
     });
   }
@@ -302,21 +356,21 @@ export default class Resolution {
     return this.fromEthereumEip1193Provider({
       uns: networks.uns
         ? {
-            locations: {
-              Layer1: {
-                network: networks.uns.locations.Layer1.network,
-                provider: Eip1193Factories.fromWeb3Version1Provider(
-                  networks.uns.locations.Layer1.provider,
-                ),
-              },
-              Layer2: {
-                network: networks.uns.locations.Layer2.network,
-                provider: Eip1193Factories.fromWeb3Version1Provider(
-                  networks.uns.locations.Layer2.provider,
-                ),
-              },
+          locations: {
+            Layer1: {
+              network: networks.uns.locations.Layer1.network,
+              provider: Eip1193Factories.fromWeb3Version1Provider(
+                networks.uns.locations.Layer1.provider,
+              ),
             },
-          }
+            Layer2: {
+              network: networks.uns.locations.Layer2.network,
+              provider: Eip1193Factories.fromWeb3Version1Provider(
+                networks.uns.locations.Layer2.provider,
+              ),
+            },
+          },
+        }
         : undefined,
     });
   }
@@ -347,21 +401,21 @@ export default class Resolution {
     return this.fromEthereumEip1193Provider({
       uns: networks.uns
         ? {
-            locations: {
-              Layer1: {
-                network: networks.uns.locations.Layer1.network,
-                provider: Eip1193Factories.fromEthersProvider(
-                  networks.uns.locations.Layer1.provider,
-                ),
-              },
-              Layer2: {
-                network: networks.uns.locations.Layer2.network,
-                provider: Eip1193Factories.fromEthersProvider(
-                  networks.uns.locations.Layer2.provider,
-                ),
-              },
+          locations: {
+            Layer1: {
+              network: networks.uns.locations.Layer1.network,
+              provider: Eip1193Factories.fromEthersProvider(
+                networks.uns.locations.Layer1.provider,
+              ),
             },
-          }
+            Layer2: {
+              network: networks.uns.locations.Layer2.network,
+              provider: Eip1193Factories.fromEthersProvider(
+                networks.uns.locations.Layer2.provider,
+              ),
+            },
+          },
+        }
         : undefined,
     });
   }

--- a/src/tests/Resolution.test.ts
+++ b/src/tests/Resolution.test.ts
@@ -15,7 +15,6 @@ import {
 import {JsonRpcProvider, InfuraProvider} from '@ethersproject/providers';
 import Web3HttpProvider from 'web3-providers-http';
 import Web3WsProvider from 'web3-providers-ws';
-import Web3V027Provider from 'web3-0.20.7/lib/web3/httpprovider';
 import {
   expectResolutionErrorCode,
   expectSpyToBeCalled,
@@ -869,53 +868,6 @@ describe('Resolution', () => {
             Promise.resolve(caseMock(params, RpcProviderTestCases)),
           );
           const resolution = Resolution.fromEthersProvider({
-            uns: {
-              locations: {
-                Layer1: {network: 'rinkeby', provider},
-                Layer2: {network: 'polygon-mumbai', provider: polygonProvider},
-              },
-            },
-          });
-          const uns = resolution.serviceMap['UNS'].native as Uns;
-          mockAsyncMethod(uns.unsl2.readerContract, 'call', (params) =>
-            Promise.resolve([NullAddress, NullAddress, {}]),
-          );
-          const ethAddress = await resolution.addr('brad.crypto', 'eth');
-          expectSpyToBeCalled([eye]);
-          expect(ethAddress).toBe('0x8aaD44321A86b170879d7A244c1e8d360c99DdA8');
-        });
-
-        it('should work with web3@0.20.7 provider', async () => {
-          const provider = new Web3V027Provider(
-            protocolLink(ProviderProtocol.http),
-            5000,
-            null,
-            null,
-            null,
-          );
-          const polygonProvider = new Web3V027Provider(
-            protocolLink(ProviderProtocol.http, 'UNSL2'),
-            5000,
-            null,
-            null,
-            null,
-          );
-          const eye = mockAsyncMethod(
-            provider,
-            'sendAsync',
-            (payload: JsonRpcPayload, callback: any) => {
-              const result = caseMock(
-                payload.params?.[0],
-                RpcProviderTestCases,
-              );
-              callback(undefined, {
-                jsonrpc: '2.0',
-                id: 1,
-                result,
-              });
-            },
-          );
-          const resolution = Resolution.fromWeb3Version0Provider({
             uns: {
               locations: {
                 Layer1: {network: 'rinkeby', provider},

--- a/src/tests/Resolution.test.ts
+++ b/src/tests/Resolution.test.ts
@@ -332,8 +332,22 @@ describe('Resolution', () => {
       throw new Error('nock is not configured correctly!');
     });
 
-    it('should get a valid resolution instance', async () => {
+    it('should get a valid resolution instance with .infura', async () => {
       const resolution = Resolution.infura('api-key', {
+        uns: {
+          locations: {
+            Layer1: {network: 'rinkeby'},
+            Layer2: {network: 'polygon-mumbai'},
+          },
+        },
+      });
+      uns = resolution.serviceMap[NamingServiceName.UNS].native as Uns;
+      expect(uns.unsl1.url).toBe(`https://rinkeby.infura.io/v3/api-key`);
+      expect(uns.unsl2.url).toBe(`https://polygon-mumbai.infura.io/v3/api-key`);
+    });
+
+    it('should get a valid resolution instance with .alchemy', async () => {
+      const resolution = Resolution.alchemy('api-key', {
         uns: {
           locations: {
             Layer1: {network: 'rinkeby'},

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -119,9 +119,12 @@ const StringUnion = <UnionType extends string>(...values: UnionType[]) => {
 export const UnsSupportedNetwork = StringUnion(
   'mainnet',
   'rinkeby',
+  'goerli',
   'polygon-mainnet',
   'polygon-mumbai',
 );
+
+export type UnsSupportedNetwork = typeof UnsSupportedNetwork.type;
 
 export const ZnsSupportedNetwork = StringUnion('mainnet', 'testnet');
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,18 +1,32 @@
 import {CryptoRecords, NamingServiceName} from '../types/publicTypes';
 import {NullAddresses} from '../types';
+import {UnsSupportedNetwork} from '../types';
 
-export function signedLink(key: string, network = 'mainnet'): string {
-  let url = 'https://eth-mainnet.alchemyapi.io/v2/';
+type Providers = 'infura' | 'alchemy';
+type NetworkSignedLinkURLs = Record<UnsSupportedNetwork, string>;
+const ProviderURLMap: Record<Providers, NetworkSignedLinkURLs> = {
+  infura: {
+    mainnet: 'https://mainnet.infura.io/v3/',
+    rinkeby: 'https://rinkeby.infura.io/v3/',
+    goerli: 'https://goerli.infura.io/v3/',
+    'polygon-mainnet': 'https://polygon-mainnet.infura.io/v3/',
+    'polygon-mumbai': 'https://polygon-mumbai.infura.io/v3/',
+  },
+  alchemy: {
+    mainnet: 'https://eth-mainnet.alchemyapi.io/v2/',
+    rinkeby: 'https://eth-rinkeby.alchemyapi.io/v2/',
+    goerli: 'https://eth-goerli.alchemyapi.io/v2/',
+    'polygon-mainnet': 'https://polygon-mainnet.g.alchemy.com/v2/',
+    'polygon-mumbai': 'https://polygon-mumbai.g.alchemy.com/v2/',
+  },
+};
 
-  switch (network) {
-  case 'polygon-mumbai':
-    url = 'https://polygon-mumbai.g.alchemy.com/v2/';
-    break;
-  case 'rinkeby':
-    url = 'https://eth-rinkeby.alchemyapi.io/v2/';
-    break;
-  }
-
+export function signedLink(
+  key: string,
+  network: UnsSupportedNetwork = 'mainnet',
+  provider: Providers = 'infura',
+): string {
+  const url = ProviderURLMap[provider][network];
   return `${url}${key}`;
 }
 


### PR DESCRIPTION
## Background
Recent changes introduced invalid default configurations that cause `Resolution` to use test networks by default.

## Changes
 - Updated default configs
 - Added `Resolution#alchemy` configuration to initialise `Resolution` with an alchemy key