### PR TITLE
Resolve .xyz as UNS domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.3.1
+
+- Resolve .xyz TLD as UNS domains
+
 ## 9.3.0
 
 - Support Base blockchain UNS domains resolution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 9.3.1
 
 - Resolve .xyz TLD as UNS domains
+- Remove .kred and .luxe from ENS resolution
 
 ## 9.3.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/resolution",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "description": "Domain Resolution for blockchain domains",
   "main": "./build/index.js",
   "directories": {

--- a/src/Ens.ts
+++ b/src/Ens.ts
@@ -513,7 +513,7 @@ export default class Ens extends NamingService {
   private checkSupportedDomain(domain: string): boolean {
     return (
       domain === 'eth' ||
-      /^([^\s\\.]+\.)+(eth|luxe|xyz|kred)+$/.test(domain) ||
+      /^([^\s\\.]+\.)+(eth|luxe|kred)+$/.test(domain) ||
       /^([^\s\\.]+\.)(addr\.)(reverse)$/.test(domain)
     );
   }

--- a/src/Ens.ts
+++ b/src/Ens.ts
@@ -513,7 +513,7 @@ export default class Ens extends NamingService {
   private checkSupportedDomain(domain: string): boolean {
     return (
       domain === 'eth' ||
-      /^([^\s\\.]+\.)+(eth|luxe|kred)+$/.test(domain) ||
+      /^([^\s\\.]+\.)+(eth)+$/.test(domain) ||
       /^([^\s\\.]+\.)(addr\.)(reverse)$/.test(domain)
     );
   }

--- a/src/Resolution.ts
+++ b/src/Resolution.ts
@@ -968,10 +968,10 @@ export default class Resolution {
   async locations(domains: string[]): Promise<Locations> {
     const zilDomains = domains.filter((domain) => domain.endsWith('.zil'));
     const ensDomains = domains.filter((domain) =>
-      domain.match(/^([^\s\\.]+\.)+(eth|luxe|kred)+$/),
+      domain.match(/^([^\s\\.]+\.)+(eth)+$/),
     );
     const nonEnsDomains = domains.filter(
-      (domain) => !domain.match(/^([^\s\\.]+\.)+(eth|luxe|kred)+$/),
+      (domain) => !domain.match(/^([^\s\\.]+\.)+(eth)+$/),
     );
     // Here, we call both UNS and ZNS methods and merge the results.
     // If any of the calls fails, this method will fail as well as we aren't interested in partial results.

--- a/src/Resolution.ts
+++ b/src/Resolution.ts
@@ -968,10 +968,10 @@ export default class Resolution {
   async locations(domains: string[]): Promise<Locations> {
     const zilDomains = domains.filter((domain) => domain.endsWith('.zil'));
     const ensDomains = domains.filter((domain) =>
-      domain.match(/^([^\s\\.]+\.)+(eth|luxe|xyz|kred)+$/),
+      domain.match(/^([^\s\\.]+\.)+(eth|luxe|kred)+$/),
     );
     const nonEnsDomains = domains.filter(
-      (domain) => !domain.match(/^([^\s\\.]+\.)+(eth|luxe|xyz|kred)+$/),
+      (domain) => !domain.match(/^([^\s\\.]+\.)+(eth|luxe|kred)+$/),
     );
     // Here, we call both UNS and ZNS methods and merge the results.
     // If any of the calls fails, this method will fail as well as we aren't interested in partial results.

--- a/src/Uns.ts
+++ b/src/Uns.ts
@@ -534,10 +534,7 @@ export default class Uns extends NamingService {
     const tokens = domain.split('.');
     return (
       !!tokens.length &&
-      !(
-        domain === 'eth' ||
-        /^[^-]*[^-]*\.(eth|luxe|kred|addr\.reverse)$/.test(domain)
-      ) &&
+      !(domain === 'eth' || /^[^-]*[^-]*\.(eth|addr\.reverse)$/.test(domain)) &&
       tokens.every((v) => !!v.length)
     );
   }

--- a/src/Uns.ts
+++ b/src/Uns.ts
@@ -536,7 +536,7 @@ export default class Uns extends NamingService {
       !!tokens.length &&
       !(
         domain === 'eth' ||
-        /^[^-]*[^-]*\.(eth|luxe|xyz|kred|addr\.reverse)$/.test(domain)
+        /^[^-]*[^-]*\.(eth|luxe|kred|addr\.reverse)$/.test(domain)
       ) &&
       tokens.every((v) => !!v.length)
     );

--- a/src/UnsInternal.ts
+++ b/src/UnsInternal.ts
@@ -163,10 +163,7 @@ export default class UnsInternal {
     const tokens = domain.split('.');
     return (
       !!tokens.length &&
-      !(
-        domain === 'eth' ||
-        /^[^-]*[^-]*\.(eth|luxe|kred|addr\.reverse)$/.test(domain)
-      ) &&
+      !(domain === 'eth' || /^[^-]*[^-]*\.(eth|addr\.reverse)$/.test(domain)) &&
       tokens.every((v) => !!v.length)
     );
   }

--- a/src/UnsInternal.ts
+++ b/src/UnsInternal.ts
@@ -165,7 +165,7 @@ export default class UnsInternal {
       !!tokens.length &&
       !(
         domain === 'eth' ||
-        /^[^-]*[^-]*\.(eth|luxe|xyz|kred|addr\.reverse)$/.test(domain)
+        /^[^-]*[^-]*\.(eth|luxe|kred|addr\.reverse)$/.test(domain)
       ) &&
       tokens.every((v) => !!v.length)
     );

--- a/src/tests/Ens.test.ts
+++ b/src/tests/Ens.test.ts
@@ -71,13 +71,13 @@ describe('ENS', () => {
         '0x4da70a332a7a98a58486f551a455b1398ce309d9bd3a4f0800da4eec299829a4',
       callMethod: '0xDa1756Bb923Af5d1a05E277CB1E54f1D0A127890',
       resolverCallToAddr: '0xb0E7a465D255aE83eb7F8a50504F3867B945164C',
-      resolverCallToName: 'adrian.argent.xyz',
+      resolverCallToName: 'adrian.argent.luxy',
     });
     const result = await ens?.reverseOf(
       '0xb0E7a465D255aE83eb7F8a50504F3867B945164C',
     );
     expectSpyToBeCalled(eyes);
-    expect(result).toEqual('adrian.argent.xyz');
+    expect(result).toEqual('adrian.argent.luxy');
   });
 
   it('reverses address to ENS domain null', async () => {
@@ -91,17 +91,6 @@ describe('ENS', () => {
     );
     expectSpyToBeCalled(spy);
     expect(result).toEqual(null);
-  });
-
-  it('resolves .xyz name using ENS blockchain', async () => {
-    const eyes = mockAsyncMethods(ens, {
-      resolver: '0xDa1756Bb923Af5d1a05E277CB1E54f1D0A127890',
-      fetchAddress: '0xb0E7a465D255aE83eb7F8a50504F3867B945164C',
-    });
-
-    const result = await resolution.addr('adrian.argent.xyz', 'ETH');
-    expectSpyToBeCalled(eyes);
-    expect(result).toEqual('0xb0E7a465D255aE83eb7F8a50504F3867B945164C');
   });
 
   it('resolves .luxe name using ENS blockchain', async () => {

--- a/src/tests/Ens.test.ts
+++ b/src/tests/Ens.test.ts
@@ -93,40 +93,6 @@ describe('ENS', () => {
     expect(result).toEqual(null);
   });
 
-  it('resolves .luxe name using ENS blockchain', async () => {
-    const eyes = mockAsyncMethods(ens, {
-      resolver: '0xBD5F5ec7ed5f19b53726344540296C02584A5237',
-      fetchAddress: '0xf3dE750A73C11a6a2863761E930BF5fE979d5663',
-    });
-
-    const result = await resolution.addr('john.luxe', 'ETH');
-    expectSpyToBeCalled(eyes);
-    expect(result).toEqual('0xf3dE750A73C11a6a2863761E930BF5fE979d5663');
-  });
-
-  it('resolves .kred name using ENS blockchain', async () => {
-    const eyes = mockAsyncMethods(ens, {
-      resolver: '0x96184444629F3489c4dE199871E6F99568229d8f',
-      fetchAddress: '0x96184444629F3489c4dE199871E6F99568229d8f',
-    });
-    const result = await resolution.addr('brantly.kred', 'ETH');
-    expectSpyToBeCalled(eyes);
-    expect(result).toEqual('0x96184444629F3489c4dE199871E6F99568229d8f');
-  });
-
-  it('resolves .luxe name using ENS blockchain with thrown error', async () => {
-    const spies = mockAsyncMethods(ens, {
-      resolver: undefined,
-      owner: undefined,
-    });
-
-    await expectResolutionErrorCode(
-      resolution.addr('something.luxe', 'ETH'),
-      ResolutionErrorCode.UnregisteredDomain,
-    );
-    expectSpyToBeCalled(spies);
-  });
-
   it('resolves name with resolver but without an owner', async () => {
     const eyes = mockAsyncMethods(ens, {
       resolver: '0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8',

--- a/src/tests/Ens.test.ts
+++ b/src/tests/Ens.test.ts
@@ -71,13 +71,13 @@ describe('ENS', () => {
         '0x4da70a332a7a98a58486f551a455b1398ce309d9bd3a4f0800da4eec299829a4',
       callMethod: '0xDa1756Bb923Af5d1a05E277CB1E54f1D0A127890',
       resolverCallToAddr: '0xb0E7a465D255aE83eb7F8a50504F3867B945164C',
-      resolverCallToName: 'adrian.argent.luxy',
+      resolverCallToName: 'adrian.argent.eth',
     });
     const result = await ens?.reverseOf(
       '0xb0E7a465D255aE83eb7F8a50504F3867B945164C',
     );
     expectSpyToBeCalled(eyes);
-    expect(result).toEqual('adrian.argent.luxy');
+    expect(result).toEqual('adrian.argent.eth');
   });
 
   it('reverses address to ENS domain null', async () => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -86,7 +86,7 @@ export function constructRecords(
   return records;
 }
 
-const EnsTlds = ['eth', 'luxe', 'xyz', 'kred', 'reverse'];
+const EnsTlds = ['eth', 'luxe', 'kred', 'reverse'];
 
 export const findNamingServiceName = async (
   domain: string,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -86,7 +86,7 @@ export function constructRecords(
   return records;
 }
 
-const EnsTlds = ['eth', 'luxe', 'kred', 'reverse'];
+const EnsTlds = ['eth', 'reverse'];
 
 export const findNamingServiceName = async (
   domain: string,


### PR DESCRIPTION
## Background / Changes

This PR resolves .xyz as UNS domains, instead of throwing an error of an unsupported domain.

## Code Review

This Pull Request was thoroughly reviewed and meets all Code Review Standards pertaining to:

- [x] **Implementation** - satisfied acceptance criteria
- [ ] **Communication** - notified engineers/stakeholders about impactful changes
- [ ] **Error handling** - handled, logged & alerted on errors
- [ ] **Documentation** - wrote readable code & commits, documented unintuitive code
- [ ] **Testing** - unit & E2E test coverage, tested in staging, DB migrations backwards compatible
- [ ] **Security** - sanitized inputs, vetted dependencies, validated/secured API requests, no committed secrets
- [ ] **Performance** - optimized expensive algorithms & database queries

Please select all **applied** standards relevant to this PR.
## Confirmation

- [x] **Assignee Confirmation** - I (the author) have filled out the template above
- [ ] **Reviewer Confirmation** - I (a/the reviewer) confirm 1) the author has filled out the template and checked the box that says **Assignee Confirmation** 2) I reviewed the code and selected all applicable items in the code review section.
