### PR TITLE
docs: fix "compatitable" -> "compatible" typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,9 +197,9 @@
 - Introduced new factory method
   `Resolution#fromZilliqaProvider -> Creates a resolution instance with configured provider from Zilliqa provider`
 - Introduced new factory method
-  `Resolution#fromResolutionProvider -> Creates a resolution from Resolution compatitable provider`
+  `Resolution#fromResolutionProvider -> Creates a resolution from Resolution compatible provider`
 - Introduced new factory method
-  `Resolution#fromEthereumEip1193Provider -> Creates a resolution from EIP-1193 compatitable provider`
+  `Resolution#fromEthereumEip1193Provider -> Creates a resolution from EIP-1193 compatible provider`
 - Return ENS support
 - Add custom network support for ENS
 


### PR DESCRIPTION
## Summary
Fix misspelling "compatitable" -> "compatible" in factory method descriptions (2 occurrences):
- `Resolution#fromResolutionProvider` description
- `Resolution#fromEthereumEip1193Provider` description

## Test plan
- [x] Verified all changes are documentation-only and do not affect code behavior