### PR TITLE
docs: fix "wheather" -> "whether" typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -483,7 +483,7 @@
 
 - Domain that starts and ends with '-' are not valid anymore in ENS.
 - Bugfix Resolution#resolve on ENS domain when resolver has no address record
-- Resolution#isValidHash method - checks wheather a domain name matches the
+- Resolution#isValidHash method - checks whether a domain name matches the
   given hash from the blockchain
 
 ## 1.0.9-1.0.10


### PR DESCRIPTION
## Summary
Fix misspelling "wheather" -> "whether" in changelog entry

## Test plan
- [x] Verified change is documentation-only and does not affect code behavior