### PR TITLE
fix: correct "depricated" -> "deprecated" typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -470,7 +470,7 @@
   ipfsHash from the domain's records
 - Deprecate Resolution#ipfsRedirect
 - Resolution#httpUrl(domain:string): Promise<string> -> method to use instead of
-  depricated Resolution#ipfsRedirect, returns an http url from the domain's
+  deprecated Resolution#ipfsRedirect, returns an http url from the domain's
   records
 - Resolution#email(domain:string): Promise<string> -> method to return an email
   from the domain's records

--- a/src/tests/Resolution.test.ts
+++ b/src/tests/Resolution.test.ts
@@ -578,7 +578,7 @@ describe('Resolution', () => {
 
       describe('.ipfsHash', () => {
         skipItInLive(
-          'should prioritize new keys over depricated ones',
+          'should prioritize new keys over deprecated ones',
           async () => {
             const spies = mockAsyncMethods(uns, {
               get: {


### PR DESCRIPTION
## Summary
- CHANGELOG.md: Fix spelling in Resolution#httpUrl description
- src/tests/Resolution.test.ts: Fix spelling in test description

## Test plan
- [x] Verified changes are documentation/test-description-only and do not affect code behavior