### PR TITLE
docs: fix "asynchronious" -> "asynchronous" typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,7 +225,7 @@
 ## 2.1.0
 
 - Introduce new factory method Resolution#autonetwork. This factory is
-  asynchronious and allows to skip the network configuration for either ens or
+  asynchronous and allows to skip the network configuration for either ens or
   cns. This method is making a "net_version" call to the blockchain provider in
   order to configure itself.
 


### PR DESCRIPTION
## Summary
Fix misspelling "asynchronious" -> "asynchronous" in changelog entry

## Test plan
- [x] Verified change is documentation-only and does not affect code behavior